### PR TITLE
Fix install.sh: create INSTALL_DIR before moving binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,10 +43,11 @@ curl -fsSL -o "$TMP" "$URL"
 
 # Install
 chmod +x "$TMP"
-if [ -w "$INSTALL_DIR" ]; then
+if [ -d "$INSTALL_DIR" ] && [ -w "$INSTALL_DIR" ]; then
   mv "$TMP" "${INSTALL_DIR}/${BINARY}"
 else
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mkdir -p "$INSTALL_DIR"
   sudo mv "$TMP" "${INSTALL_DIR}/${BINARY}"
 fi
 


### PR DESCRIPTION
install.sh failed with No such file or directory when INSTALL_DIR (default /usr/local/bin) did not exist. Added a directory existence check and sudo mkdir -p before moving the binary.
<img width="1784" height="248" alt="image" src="https://github.com/user-attachments/assets/b307f566-7ccb-4d39-abb7-279b608bd1d5" />
