### PR TITLE
Fix: detect agents installed via version managers (nvm, mise, etc.)

### DIFF
--- a/config/detect.go
+++ b/config/detect.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -55,7 +56,7 @@ func DetectAndConfigure(cfg *Config) bool {
 			continue
 		}
 
-		path, err := exec.LookPath(candidate.Binary)
+		path, err := lookPath(candidate.Binary)
 		if err != nil {
 			continue
 		}
@@ -199,4 +200,32 @@ func loadOpenclawGateway() (gwURL, gwToken, gwPassword string) {
 func agentExists(cfg *Config, name string) bool {
 	_, ok := cfg.Agents[name]
 	return ok
+}
+
+// lookPath finds a binary by name. It first tries exec.LookPath (fast, uses
+// current PATH). If that fails, it falls back to resolving via a login shell
+// which sources the user's profile (~/.zshrc, ~/.bashrc) — this picks up
+// binaries installed through version managers like nvm, mise, etc. that only
+// add their paths in interactive shells.
+func lookPath(binary string) (string, error) {
+	// Fast path: binary is in current PATH
+	if p, err := exec.LookPath(binary); err == nil {
+		return p, nil
+	}
+
+	// Fallback: resolve via login interactive shell (sources .zshrc/.bashrc)
+	shell := "zsh"
+	if runtime.GOOS != "darwin" {
+		shell = "bash"
+	}
+	out, err := exec.Command(shell, "-lic", "which "+binary).Output()
+	if err != nil {
+		return "", fmt.Errorf("not found: %s", binary)
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" || strings.Contains(p, "not found") {
+		return "", fmt.Errorf("not found: %s", binary)
+	}
+	log.Printf("[config] resolved %s via login shell: %s", binary, p)
+	return p, nil
 }

--- a/config/detect_test.go
+++ b/config/detect_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestLookPath_InPath verifies that lookPath finds binaries already in PATH.
+func TestLookPath_InPath(t *testing.T) {
+	p, err := lookPath("ls")
+	if err != nil {
+		t.Fatalf("expected to find ls, got error: %v", err)
+	}
+	if p == "" {
+		t.Fatal("expected non-empty path for ls")
+	}
+}
+
+// TestLookPath_NotExist verifies that lookPath returns an error for missing binaries.
+func TestLookPath_NotExist(t *testing.T) {
+	_, err := lookPath("nonexistent-binary-xyz-12345")
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+}
+
+// TestLookPath_LoginShellFallback reproduces the daemon scenario:
+// PATH is stripped to system-only dirs (no nvm), so exec.LookPath fails,
+// but lookPath resolves claude via login shell fallback.
+func TestLookPath_LoginShellFallback(t *testing.T) {
+	// Precondition: claude must be discoverable via login shell (i.e. nvm in .zshrc)
+	fullPath, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("claude not installed, skipping login shell fallback test")
+	}
+
+	// Simulate daemon environment: strip PATH to system-only dirs
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+	defer os.Setenv("PATH", origPath)
+
+	// Reproduce the bug: exec.LookPath must fail under stripped PATH
+	_, err = exec.LookPath("claude")
+	if err == nil {
+		t.Skip("claude found in minimal PATH, cannot reproduce nvm issue")
+	}
+
+	// Verify fix: lookPath should find claude via login shell
+	p, err := lookPath("claude")
+	if err != nil {
+		t.Fatalf("lookPath should find claude via login shell, got: %v", err)
+	}
+	if p != fullPath {
+		t.Logf("resolved path differs: direct=%s, login-shell=%s (acceptable)", fullPath, p)
+	}
+	t.Logf("lookPath resolved claude via login shell: %s", p)
+}
+
+// TestDetectAndConfigure_StrippedPath is an end-to-end test:
+// empty config + stripped PATH → DetectAndConfigure should still find claude.
+func TestDetectAndConfigure_StrippedPath(t *testing.T) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		t.Skip("claude not installed, skipping")
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+	defer os.Setenv("PATH", origPath)
+
+	cfg := DefaultConfig()
+	DetectAndConfigure(cfg)
+
+	agent, ok := cfg.Agents["claude"]
+	if !ok {
+		t.Fatal("expected claude to be detected via login shell fallback")
+	}
+	if agent.Type != "cli" {
+		t.Fatalf("expected type=cli, got %s", agent.Type)
+	}
+	t.Logf("detected claude: type=%s, command=%s", agent.Type, agent.Command)
+}


### PR DESCRIPTION
Closes #12

## Problem

Daemon processes don't source shell profiles (`.zshrc`/`.bashrc`), so `exec.LookPath` fails for binaries installed via version managers like nvm, mise, etc. This causes `DetectAndConfigure` to miss `claude` even when it's installed — on a fresh/empty config, the agent is never detected.

## Root Cause

`exec.LookPath` only searches the current process's `PATH`. When weclaw runs as a daemon (`Setsid: true`), the `PATH` doesn't include nvm's bin directory (e.g. `~/.nvm/versions/node/v24.11.1/bin/`), because those paths are added in `.zshrc` which is only sourced for interactive shells.

## Solution

Add a `lookPath()` helper that falls back to resolving via a login interactive shell (`zsh -lic which <binary>`) when the standard `exec.LookPath` fails. The `-li` flags ensure `.zshrc`/`.bashrc` are sourced, picking up version manager paths.

## Test Plan

Added `config/detect_test.go` with 4 test cases:

- **TestLookPath_InPath** — finds standard binaries already in PATH
- **TestLookPath_NotExist** — returns error for missing binaries
- **TestLookPath_LoginShellFallback** — reproduces daemon scenario: strips PATH to system-only dirs, verifies `exec.LookPath` fails but `lookPath` succeeds via login shell
- **TestDetectAndConfigure_StrippedPath** — end-to-end: empty config + stripped PATH → claude detected as CLI agent