### PR TITLE
Add /new and /clear commands to reset agent session

### DIFF
--- a/agent/acp_agent.go
+++ b/agent/acp_agent.go
@@ -244,6 +244,21 @@ func (a *ACPAgent) Stop() {
 	a.started = false
 }
 
+// ResetSession clears the existing session for the given conversationID and
+// immediately creates a new one, returning the new session ID.
+func (a *ACPAgent) ResetSession(ctx context.Context, conversationID string) (string, error) {
+	a.mu.Lock()
+	delete(a.sessions, conversationID)
+	a.mu.Unlock()
+	log.Printf("[acp] session reset (conversation=%s), creating new session", conversationID)
+
+	sessionID, _, err := a.getOrCreateSession(ctx, conversationID)
+	if err != nil {
+		return "", fmt.Errorf("create new session: %w", err)
+	}
+	return sessionID, nil
+}
+
 // Chat sends a message and returns the full response.
 func (a *ACPAgent) Chat(ctx context.Context, conversationID string, message string) (string, error) {
 	if !a.started {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -42,6 +42,12 @@ type Agent interface {
 	// conversationID is used to maintain conversation history per user.
 	Chat(ctx context.Context, conversationID string, message string) (string, error)
 
+	// ResetSession clears the existing session for the given conversationID and
+	// starts a new one. Returns the new session ID if immediately available
+	// (ACP mode), or an empty string if the ID will be assigned on next Chat
+	// (CLI mode) or is not applicable (HTTP mode).
+	ResetSession(ctx context.Context, conversationID string) (string, error)
+
 	// Info returns metadata about this agent.
 	Info() AgentInfo
 }

--- a/agent/cli_agent.go
+++ b/agent/cli_agent.go
@@ -68,6 +68,17 @@ func (a *CLIAgent) Info() AgentInfo {
 	}
 }
 
+// ResetSession clears the existing session for the given conversationID.
+// Returns an empty string because the new session ID is only known after the
+// next Chat call (claude assigns it during the conversation).
+func (a *CLIAgent) ResetSession(_ context.Context, conversationID string) (string, error) {
+	a.mu.Lock()
+	delete(a.sessions, conversationID)
+	a.mu.Unlock()
+	log.Printf("[cli] session reset (command=%s, conversation=%s)", a.command, conversationID)
+	return "", nil
+}
+
 // Chat sends a message to the CLI agent and returns the response.
 func (a *CLIAgent) Chat(ctx context.Context, conversationID string, message string) (string, error) {
 	switch a.name {

--- a/agent/http_agent.go
+++ b/agent/http_agent.go
@@ -67,6 +67,15 @@ func (a *HTTPAgent) Info() AgentInfo {
 	}
 }
 
+// ResetSession clears the conversation history for the given conversationID.
+// HTTP agents have no server-side session ID, so an empty string is returned.
+func (a *HTTPAgent) ResetSession(_ context.Context, conversationID string) (string, error) {
+	a.mu.Lock()
+	delete(a.history, conversationID)
+	a.mu.Unlock()
+	return "", nil
+}
+
 // Chat sends a message to the OpenAI-compatible API and returns the response.
 func (a *HTTPAgent) Chat(ctx context.Context, conversationID string, message string) (string, error) {
 	a.mu.Lock()

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -184,6 +184,12 @@ func (h *Handler) HandleMessage(ctx context.Context, client *ilink.Client, msg i
 			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
 		}
 		return
+	} else if trimmed == "/new" || trimmed == "/clear" {
+		reply := h.resetDefaultSession(ctx, msg.FromUserID)
+		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
+			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
+		}
+		return
 	}
 
 	// Route: "/agentname message" -> specific agent, otherwise -> default
@@ -300,6 +306,24 @@ func (h *Handler) switchDefault(ctx context.Context, name string) string {
 	return fmt.Sprintf("switch to %s", name)
 }
 
+// resetDefaultSession resets the session for the given userID on the default agent.
+func (h *Handler) resetDefaultSession(ctx context.Context, userID string) string {
+	ag := h.getDefaultAgent()
+	if ag == nil {
+		return "No agent running."
+	}
+	name := ag.Info().Name
+	sessionID, err := ag.ResetSession(ctx, userID)
+	if err != nil {
+		log.Printf("[handler] reset session failed for %s: %v", userID, err)
+		return fmt.Sprintf("Failed to reset session: %v", err)
+	}
+	if sessionID != "" {
+		return fmt.Sprintf("已创建新的%s会话\n%s", name, sessionID)
+	}
+	return fmt.Sprintf("已创建新的%s会话", name)
+}
+
 // buildStatus returns a short status string showing the current default agent.
 func (h *Handler) buildStatus() string {
 	h.mu.RLock()
@@ -322,6 +346,7 @@ func buildHelpText() string {
 	return `Available commands:
 /agentname - Switch default agent
 /agentname message - Send message to a specific agent
+/new or /clear - Start a new session (clears conversation history)
 /status - Show current agent info
 /help - Show this help message
 


### PR DESCRIPTION
## Summary

- Add `ResetSession(ctx, conversationID) (string, error)` to the `Agent` interface
- **ACP mode**: deletes the old session and immediately calls `session/new`, returning the new session ID to the user
- **CLI mode**: removes the session entry from the in-memory map; a new session ID is assigned by the underlying tool (e.g. claude) on the next `Chat` call
- **HTTP mode**: clears the in-memory conversation history
- **Handler**: `/new` and `/clear` are now built-in commands — replies with `已创建新的<agent>会话\n<sessionID>` (session ID included when available from ACP)
- Updated `/help` text to document the new commands

## Behaviour

| Command | Effect |
|---------|--------|
| `/new` | Resets session for the current default agent |
| `/clear` | Alias for `/new` |

Reply examples:
- ACP agent: `已创建新的claude会话\nsess_abc123...`
- CLI / HTTP agent: `已创建新的claude会话`

## Test plan

- [x] Send `/new` while default agent is an ACP agent — verify reply contains new session ID and subsequent messages start a fresh conversation
- [x] Send `/clear` while default agent is a CLI agent — verify reply confirms reset and next message begins a new session
- [x] Send `/new` while default agent is an HTTP agent — verify conversation history is cleared
- [x] Send `/help` — verify new commands appear in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)