### PR TITLE
feat: allow configuring environment variables for CLI and ACP agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,17 @@ Config file: `~/.weclaw/config.json`
     "claude": {
       "type": "acp",
       "command": "/usr/local/bin/claude-agent-acp",
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx"
+      },
       "model": "sonnet"
     },
     "codex": {
       "type": "acp",
-      "command": "/usr/local/bin/codex-acp"
+      "command": "/usr/local/bin/codex-acp",
+      "env": {
+        "OPENAI_API_KEY": "sk-xxx"
+      }
     },
     "openclaw": {
       "type": "http",
@@ -163,6 +169,22 @@ Environment variables:
 - `WECLAW_DEFAULT_AGENT` — override default agent
 - `OPENCLAW_GATEWAY_URL` — OpenClaw HTTP fallback endpoint
 - `OPENCLAW_GATEWAY_TOKEN` — OpenClaw API token
+
+Custom agent CLI environment variables:
+
+```json
+{
+  "default_agent": "...",
+  "agents": {
+    "...": {
+      ...
+      "env": {
+        "ENV_NAME": "ENV_VALUE"
+      }
+    },
+  }
+}
+```
 
 ### Permission bypass
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -144,11 +144,17 @@ curl -X POST http://127.0.0.1:18011/api/send \
     "claude": {
       "type": "acp",
       "command": "/usr/local/bin/claude-agent-acp",
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx"
+      },
       "model": "sonnet"
     },
     "codex": {
       "type": "acp",
-      "command": "/usr/local/bin/codex-acp"
+      "command": "/usr/local/bin/codex-acp",
+      "env": {
+        "OPENAI_API_KEY": "sk-xxx"
+      }
     },
     "openclaw": {
       "type": "http",
@@ -165,6 +171,22 @@ curl -X POST http://127.0.0.1:18011/api/send \
 - `WECLAW_DEFAULT_AGENT` — 覆盖默认 Agent
 - `OPENCLAW_GATEWAY_URL` — OpenClaw HTTP 回退地址
 - `OPENCLAW_GATEWAY_TOKEN` — OpenClaw API Token
+
+自定义 agent cli 环境变量
+
+```json
+{
+  "default_agent": "...",
+  "agents": {
+    "...": {
+      ...
+      "env": {
+        "ENV_NAME": "ENV_VALUE"
+      }
+    },
+  }
+}
+```
 
 ### 权限配置
 

--- a/agent/acp_agent.go
+++ b/agent/acp_agent.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -21,6 +22,7 @@ type ACPAgent struct {
 	model        string
 	systemPrompt string
 	cwd          string
+	env          map[string]string
 
 	mu       sync.Mutex
 	cmd      *exec.Cmd
@@ -47,7 +49,8 @@ type ACPAgentConfig struct {
 	Args         []string // extra args for command (e.g. ["acp"] for cursor)
 	Model        string
 	SystemPrompt string
-	Cwd          string // working directory
+	Cwd          string            // working directory
+	Env          map[string]string // extra environment variables
 }
 
 // --- JSON-RPC types ---
@@ -150,6 +153,7 @@ func NewACPAgent(cfg ACPAgentConfig) *ACPAgent {
 		model:        cfg.Model,
 		systemPrompt: cfg.SystemPrompt,
 		cwd:          cfg.Cwd,
+		env:          cfg.Env,
 		sessions:     make(map[string]string),
 		pending:      make(map[int64]chan *rpcResponse),
 		notifyCh:     make(map[string]chan *sessionUpdate),
@@ -166,6 +170,14 @@ func (a *ACPAgent) Start(ctx context.Context) error {
 
 	a.cmd = exec.CommandContext(ctx, a.command, a.args...)
 	a.cmd.Dir = a.cwd
+	if len(a.env) > 0 {
+		cmdEnv, err := mergeEnv(os.Environ(), a.env)
+		if err != nil {
+			a.mu.Unlock()
+			return fmt.Errorf("build acp env: %w", err)
+		}
+		a.cmd.Env = cmdEnv
+	}
 	// Capture stderr for debugging and error reporting
 	a.stderr = &acpStderrWriter{prefix: "[acp-stderr]"}
 	a.cmd.Stderr = a.stderr

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 // AgentInfo holds metadata about an agent for logging/debugging.
@@ -34,6 +36,43 @@ func defaultWorkspace() string {
 	dir := filepath.Join(home, ".weclaw", "workspace")
 	os.MkdirAll(dir, 0o755)
 	return dir
+}
+
+// mergeEnv merges extra environment variables into the base environment.
+func mergeEnv(base []string, extra map[string]string) ([]string, error) {
+	if len(extra) == 0 {
+		return base, nil
+	}
+
+	merged := append([]string(nil), base...)
+	indexByKey := make(map[string]int, len(base))
+	for i, entry := range merged {
+		key, _, found := strings.Cut(entry, "=")
+		if !found || key == "" {
+			continue
+		}
+		indexByKey[key] = i
+	}
+
+	newKeys := make([]string, 0, len(extra))
+	for key, value := range extra {
+		if key == "" || strings.Contains(key, "=") {
+			return nil, fmt.Errorf("invalid env key %q", key)
+		}
+		entry := key + "=" + value
+		if idx, ok := indexByKey[key]; ok {
+			merged[idx] = entry
+			continue
+		}
+		newKeys = append(newKeys, key)
+	}
+
+	sort.Strings(newKeys)
+	for _, key := range newKeys {
+		merged = append(merged, key+"="+extra[key])
+	}
+
+	return merged, nil
 }
 
 // Agent is the interface for AI chat agents.

--- a/agent/cli_agent.go
+++ b/agent/cli_agent.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -15,8 +16,9 @@ import (
 type CLIAgent struct {
 	name         string
 	command      string
-	args         []string // extra args from config
-	cwd          string   // working directory
+	args         []string          // extra args from config
+	cwd          string            // working directory
+	env          map[string]string // extra environment variables
 	model        string
 	systemPrompt string
 	mu           sync.Mutex
@@ -25,10 +27,11 @@ type CLIAgent struct {
 
 // CLIAgentConfig holds configuration for a CLI agent.
 type CLIAgentConfig struct {
-	Name         string   // agent name for logging, e.g. "claude", "codex"
-	Command      string   // path to binary
-	Args         []string // extra args (e.g. ["--dangerously-skip-permissions"])
-	Cwd          string   // working directory (workspace)
+	Name         string            // agent name for logging, e.g. "claude", "codex"
+	Command      string            // path to binary
+	Args         []string          // extra args (e.g. ["--dangerously-skip-permissions"])
+	Cwd          string            // working directory (workspace)
+	Env          map[string]string // extra environment variables
 	Model        string
 	SystemPrompt string
 }
@@ -44,6 +47,7 @@ func NewCLIAgent(cfg CLIAgentConfig) *CLIAgent {
 		command:      cfg.Command,
 		args:         cfg.Args,
 		cwd:          cwd,
+		env:          cfg.Env,
 		model:        cfg.Model,
 		systemPrompt: cfg.SystemPrompt,
 		sessions:     make(map[string]string),
@@ -106,6 +110,13 @@ func (a *CLIAgent) chatClaude(ctx context.Context, conversationID string, messag
 	cmd := exec.CommandContext(ctx, a.command, args...)
 	if a.cwd != "" {
 		cmd.Dir = a.cwd
+	}
+	if len(a.env) > 0 {
+		cmdEnv, err := mergeEnv(os.Environ(), a.env)
+		if err != nil {
+			return "", fmt.Errorf("build %s env: %w", a.name, err)
+		}
+		cmd.Env = cmdEnv
 	}
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -195,6 +206,13 @@ func (a *CLIAgent) chatCodex(ctx context.Context, message string) (string, error
 	cmd := exec.CommandContext(ctx, a.command, args...)
 	if a.cwd != "" {
 		cmd.Dir = a.cwd
+	}
+	if len(a.env) > 0 {
+		cmdEnv, err := mergeEnv(os.Environ(), a.env)
+		if err != nil {
+			return "", fmt.Errorf("build %s env: %w", a.name, err)
+		}
+		cmd.Env = cmdEnv
 	}
 	var stderr strings.Builder
 	cmd.Stderr = &stderr

--- a/agent/env_test.go
+++ b/agent/env_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeEnvOverridesAndAppends(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "KEEP=1", "DUP=old"}
+	extra := map[string]string{
+		"NEW":   "2",
+		"DUP":   "new",
+		"EMPTY": "",
+	}
+
+	got, err := mergeEnv(base, extra)
+	if err != nil {
+		t.Fatalf("mergeEnv returned error: %v", err)
+	}
+
+	want := []string{"PATH=/usr/bin", "KEEP=1", "DUP=new", "EMPTY=", "NEW=2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeEnv() = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeEnvRejectsInvalidKey(t *testing.T) {
+	_, err := mergeEnv(nil, map[string]string{"BAD=KEY": "value"})
+	if err == nil {
+		t.Fatal("mergeEnv() error = nil, want invalid env key error")
+	}
+}
+
+func TestMergeEnvPreservesBaseWhenNoExtra(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "KEEP=1"}
+
+	got, err := mergeEnv(base, nil)
+	if err != nil {
+		t.Fatalf("mergeEnv returned error: %v", err)
+	}
+	if !reflect.DeepEqual(got, base) {
+		t.Fatalf("mergeEnv() = %#v, want %#v", got, base)
+	}
+}
+
+func TestMergeEnvRejectsEmptyKey(t *testing.T) {
+	_, err := mergeEnv(nil, map[string]string{"": "value"})
+	if err == nil {
+		t.Fatal("mergeEnv() error = nil, want empty env key error")
+	}
+}
+
+func TestMergeEnvOverridesExistingKeyWithEmptyValue(t *testing.T) {
+	got, err := mergeEnv([]string{"EMPTY=old"}, map[string]string{"EMPTY": ""})
+	if err != nil {
+		t.Fatalf("mergeEnv returned error: %v", err)
+	}
+	want := []string{"EMPTY="}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergeEnv() = %#v, want %#v", got, want)
+	}
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fastclaw-ai/weclaw/api"
 	"github.com/fastclaw-ai/weclaw/agent"
+	"github.com/fastclaw-ai/weclaw/api"
 	"github.com/fastclaw-ai/weclaw/config"
 	"github.com/fastclaw-ai/weclaw/ilink"
 	"github.com/fastclaw-ai/weclaw/messaging"
@@ -224,6 +224,7 @@ func createAgentByName(ctx context.Context, cfg *config.Config, name string) age
 			Command:      agCfg.Command,
 			Args:         agCfg.Args,
 			Cwd:          agCfg.Cwd,
+			Env:          agCfg.Env,
 			Model:        agCfg.Model,
 			SystemPrompt: agCfg.SystemPrompt,
 		})
@@ -239,6 +240,7 @@ func createAgentByName(ctx context.Context, cfg *config.Config, name string) age
 			Command:      agCfg.Command,
 			Args:         agCfg.Args,
 			Cwd:          agCfg.Cwd,
+			Env:          agCfg.Env,
 			Model:        agCfg.Model,
 			SystemPrompt: agCfg.SystemPrompt,
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -16,15 +16,16 @@ type Config struct {
 
 // AgentConfig holds configuration for a single agent.
 type AgentConfig struct {
-	Type         string   `json:"type"`                    // "acp", "cli", or "http"
-	Command      string   `json:"command,omitempty"`        // binary path (cli/acp type)
-	Args         []string `json:"args,omitempty"`           // extra args for command (e.g. ["acp"] for cursor)
-	Cwd          string   `json:"cwd,omitempty"`            // working directory (workspace)
-	Model        string   `json:"model,omitempty"`          // model name
-	SystemPrompt string   `json:"system_prompt,omitempty"`  // system prompt
-	Endpoint     string   `json:"endpoint,omitempty"`       // API endpoint (http type)
-	APIKey       string   `json:"api_key,omitempty"`        // API key (http type)
-	MaxHistory   int      `json:"max_history,omitempty"`    // max history (http type)
+	Type         string            `json:"type"`                    // "acp", "cli", or "http"
+	Command      string            `json:"command,omitempty"`       // binary path (cli/acp type)
+	Args         []string          `json:"args,omitempty"`          // extra args for command (e.g. ["acp"] for cursor)
+	Cwd          string            `json:"cwd,omitempty"`           // working directory (workspace)
+	Env          map[string]string `json:"env,omitempty"`           // extra environment variables (cli/acp type)
+	Model        string            `json:"model,omitempty"`         // model name
+	SystemPrompt string            `json:"system_prompt,omitempty"` // system prompt
+	Endpoint     string            `json:"endpoint,omitempty"`      // API endpoint (http type)
+	APIKey       string            `json:"api_key,omitempty"`       // API key (http type)
+	MaxHistory   int               `json:"max_history,omitempty"`   // max history (http type)
 }
 
 // DefaultConfig returns an empty configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAgentConfigUnmarshalEnv(t *testing.T) {
+	var cfg Config
+	data := []byte(`{
+		"agents": {
+			"claude": {
+				"type": "cli",
+				"command": "claude",
+				"env": {
+					"ANTHROPIC_API_KEY": "test-key",
+					"EMPTY": ""
+				}
+			}
+		}
+	}`)
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	ag, ok := cfg.Agents["claude"]
+	if !ok {
+		t.Fatalf("expected claude agent config")
+	}
+	if got := ag.Env["ANTHROPIC_API_KEY"]; got != "test-key" {
+		t.Fatalf("ANTHROPIC_API_KEY = %q, want %q", got, "test-key")
+	}
+	if got, ok := ag.Env["EMPTY"]; !ok || got != "" {
+		t.Fatalf("EMPTY = %q, present=%v; want empty string present", got, ok)
+	}
+}
+
+func TestAgentConfigMarshalEnvRoundTrip(t *testing.T) {
+	cfg := Config{
+		Agents: map[string]AgentConfig{
+			"claude": {
+				Type:    "cli",
+				Command: "claude",
+				Env: map[string]string{
+					"ANTHROPIC_API_KEY": "test-key",
+					"EMPTY":             "",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+
+	var decoded Config
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+
+	got := decoded.Agents["claude"].Env
+	if got["ANTHROPIC_API_KEY"] != "test-key" || got["EMPTY"] != "" {
+		t.Fatalf("round-trip env = %#v", got)
+	}
+}
+
+func TestAgentConfigWithoutEnvStillLoads(t *testing.T) {
+	var cfg Config
+	data := []byte(`{
+		"agents": {
+			"claude": {
+				"type": "cli",
+				"command": "claude"
+			}
+		}
+	}`)
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config without env: %v", err)
+	}
+
+	if cfg.Agents["claude"].Env != nil {
+		t.Fatalf("Env = %#v, want nil", cfg.Agents["claude"].Env)
+	}
+}
+
+func TestDefaultConfigInitializesAgentsMap(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Agents == nil {
+		t.Fatal("DefaultConfig() Agents = nil, want initialized map")
+	}
+}
+
+func TestLoadEnvOverridesTopLevelOnly(t *testing.T) {
+	t.Setenv("WECLAW_DEFAULT_AGENT", "codex")
+	t.Setenv("WECLAW_API_ADDR", "127.0.0.1:18011")
+
+	cfg := DefaultConfig()
+	cfg.Agents["claude"] = AgentConfig{
+		Type: "cli",
+		Env: map[string]string{
+			"KEEP": "value",
+		},
+	}
+
+	loadEnv(cfg)
+
+	if cfg.DefaultAgent != "codex" {
+		t.Fatalf("DefaultAgent = %q, want %q", cfg.DefaultAgent, "codex")
+	}
+	if cfg.APIAddr != "127.0.0.1:18011" {
+		t.Fatalf("APIAddr = %q, want %q", cfg.APIAddr, "127.0.0.1:18011")
+	}
+	if got := cfg.Agents["claude"].Env["KEEP"]; got != "value" {
+		t.Fatalf("agent env = %q, want preserved value", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add per-agent `env` support to configuration (`config.AgentConfig`) for subprocess-backed agents.
- Thread `env` from config loading into agent construction (`cmd/start.go` -> `CLIAgentConfig` / `ACPAgentConfig`).
- Apply merged environment variables to spawned processes in:
  - `agent/cli_agent.go` (`chatClaude`, `chatCodex`)
  - `agent/acp_agent.go` (`Start`)
- Introduce shared env merge helper in `agent/agent.go` to:
  - start from inherited `os.Environ()`
  - override duplicate keys with configured values
  - preserve empty values (`KEY=`)
  - reject invalid keys (empty or containing `=`)
  - keep deterministic ordering for appended keys
- Add focused tests:
  - `config/config_test.go` (env unmarshal/round-trip/backward compatibility)
  - `agent/env_test.go` (merge semantics and invalid-key handling)
- Update docs in `README.md` and `README_CN.md` with `env` examples and behavior notes.

## Behavior Notes

- `agents.<name>.env` is used for `cli` and `acp` agents only.
- `http` agents continue to ignore `env`.
- Existing configs without `env` remain fully compatible.
- `cwd` behavior is unchanged (`~/.weclaw/workspace` fallback still applies).

## Testing

- [x] `go test ./config ./agent`
- [x] `go test ./...`

## Files Changed

- `config/config.go`
- `config/config_test.go`
- `cmd/start.go`
- `agent/agent.go`
- `agent/env_test.go`
- `agent/cli_agent.go`
- `agent/acp_agent.go`
- `README.md`
- `README_CN.md`
