### PR TITLE
Add all missing ACP agents from acpx registry

### DIFF
--- a/config/detect.go
+++ b/config/detect.go
@@ -41,12 +41,19 @@ var agentCandidates = []agentCandidate{
 	{Name: "gemini", Binary: "gemini", Args: []string{"--acp"}, Type: "acp", Model: ""},
 	{Name: "opencode", Binary: "opencode", Args: []string{"acp"}, Type: "acp", Model: ""},
 	{Name: "openclaw", Binary: "openclaw", Type: "acp", Model: "openclaw:main"}, // args built dynamically
+	{Name: "pi", Binary: "pi-acp", Type: "acp", Model: ""},
+	{Name: "copilot", Binary: "copilot", Args: []string{"--acp", "--stdio"}, Type: "acp", Model: ""},
+	{Name: "droid", Binary: "droid", Args: []string{"exec", "--output-format", "acp"}, Type: "acp", Model: ""},
+	{Name: "iflow", Binary: "iflow", Args: []string{"--experimental-acp"}, Type: "acp", Model: ""},
+	{Name: "kiro", Binary: "kiro-cli", Args: []string{"acp"}, Type: "acp", Model: ""},
+	{Name: "qwen", Binary: "qwen", Args: []string{"--acp"}, Type: "acp", Model: ""},
 }
 
 // defaultOrder defines the priority for choosing the default agent.
 // Lower index = higher priority.
 var defaultOrder = []string{
 	"claude", "codex", "cursor", "kimi", "gemini", "opencode", "openclaw",
+	"pi", "copilot", "droid", "iflow", "kiro", "qwen",
 }
 
 // DetectAndConfigure auto-detects local agents and populates the config.

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -149,6 +149,12 @@ var agentAliases = map[string]string{
 	"km":  "kimi",
 	"gm":  "gemini",
 	"ocd": "opencode",
+	"pi":  "pi",
+	"cp":  "copilot",
+	"dr":  "droid",
+	"if":  "iflow",
+	"kr":  "kiro",
+	"qw":  "qwen",
 }
 
 // resolveAlias returns the full agent name for an alias, or the original name if no alias matches.
@@ -602,7 +608,7 @@ func buildHelpText() string {
 /info - Show current agent info
 /help - Show this help message
 
-Aliases: /cc(claude) /cx(codex) /cs(cursor) /km(kimi) /gm(gemini) /oc(openclaw) /ocd(opencode)`
+Aliases: /cc(claude) /cx(codex) /cs(cursor) /km(kimi) /gm(gemini) /oc(openclaw) /ocd(opencode) /pi(pi) /cp(copilot) /dr(droid) /if(iflow) /kr(kiro) /qw(qwen)`
 }
 
 func extractText(msg ilink.WeixinMessage) string {


### PR DESCRIPTION
## Changes

Add 6 new ACP agents to auto-detection, built-in aliases, and default priority order.

### New agents

| Agent | Binary | Args | Alias |
|-------|--------|------|-------|
| Pi | `pi-acp` | — | `/pi` |
| Copilot | `copilot` | `--acp --stdio` | `/cp` |
| Droid | `droid` | `exec --output-format acp` | `/dr` |
| iFlow | `iflow` | `--experimental-acp` | `/if` |
| Kiro | `kiro-cli` | `acp` | `/kr` |
| Qwen | `qwen` | `--acp` | `/qw` |

### Files changed
- **config/detect.go**: Added 6 agent candidates + appended to `defaultOrder`
- **messaging/handler.go**: Added 6 built-in aliases + updated help text