### PR TITLE
Add CI test workflow, multi-stage builds, and messaging tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+    tags-ignore: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -count=1 -race -v
+
+  build:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Determine version
+        id: version
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "version=v0.0.0-beta+${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=v0.0.0-alpha+${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
+          go build -trimpath -ldflags="-s -w -X github.com/fastclaw-ai/weclaw/cmd.Version=${{ steps.version.outputs.version }}" \
+            -o weclaw_${{ matrix.goos }}_${{ matrix.goarch }}${EXT} .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: weclaw_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: weclaw_${{ matrix.goos }}_${{ matrix.goarch }}*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum weclaw_* > checksums.txt
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "tag=beta-latest" >> "$GITHUB_OUTPUT"
+            echo "name=Beta (main @ $(echo ${{ github.sha }} | cut -c1-7))" >> "$GITHUB_OUTPUT"
+          else
+            SAFE_BRANCH=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            echo "tag=alpha-${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "name=Alpha (${SAFE_BRANCH} @ $(echo ${{ github.sha }} | cut -c1-7))" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete "${{ steps.tag.outputs.tag }}" --repo "${{ github.repository }}" --yes 2>/dev/null || true
+
+      - name: Create pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.name }}
+          prerelease: true
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/weclaw_*
+            dist/checksums.txt
+          body: |
+            Pre-release build from `${{ github.ref_name }}` branch.
+            Commit: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
             goarch: arm64
           - goos: windows
             goarch: amd64
+          - goos: windows
+            goarch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +40,15 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -ldflags="-s -w -X github.com/fastclaw-ai/weclaw/cmd.Version=${{ github.ref_name }}" \
-            -o weclaw_${{ matrix.goos }}_${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }} .
+          EXT=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
+          go build -trimpath -ldflags="-s -w -X github.com/fastclaw-ai/weclaw/cmd.Version=${{ github.ref_name }}" \
+            -o weclaw_${{ matrix.goos }}_${{ matrix.goarch }}${EXT} .
 
       - uses: actions/upload-artifact@v4
         with:
           name: weclaw_${{ matrix.goos }}_${{ matrix.goarch }}
-          path: weclaw_${{ matrix.goos }}_${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+          path: weclaw_${{ matrix.goos }}_${{ matrix.goarch }}*
 
   release:
     needs: build

--- a/messaging/handler_test.go
+++ b/messaging/handler_test.go
@@ -1,0 +1,140 @@
+package messaging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fastclaw-ai/weclaw/agent"
+)
+
+func newTestHandler() *Handler {
+	return &Handler{agents: make(map[string]agent.Agent)}
+}
+
+func TestParseCommand_NoPrefix(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("hello world")
+	if len(names) != 0 {
+		t.Errorf("expected nil names, got %v", names)
+	}
+	if msg != "hello world" {
+		t.Errorf("expected full text, got %q", msg)
+	}
+}
+
+func TestParseCommand_SlashWithAgent(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("/claude explain this code")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude], got %v", names)
+	}
+	if msg != "explain this code" {
+		t.Errorf("expected 'explain this code', got %q", msg)
+	}
+}
+
+func TestParseCommand_AtPrefix(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("@claude explain this code")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude], got %v", names)
+	}
+	if msg != "explain this code" {
+		t.Errorf("expected 'explain this code', got %q", msg)
+	}
+}
+
+func TestParseCommand_MultiAgent(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("@cc @cx hello")
+	if len(names) != 2 || names[0] != "claude" || names[1] != "codex" {
+		t.Errorf("expected [claude codex], got %v", names)
+	}
+	if msg != "hello" {
+		t.Errorf("expected 'hello', got %q", msg)
+	}
+}
+
+func TestParseCommand_MultiAgentDedup(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("@cc @cc hello")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude] (deduped), got %v", names)
+	}
+	if msg != "hello" {
+		t.Errorf("expected 'hello', got %q", msg)
+	}
+}
+
+func TestParseCommand_SwitchOnly(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("/claude")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude], got %v", names)
+	}
+	if msg != "" {
+		t.Errorf("expected empty message, got %q", msg)
+	}
+}
+
+func TestParseCommand_Alias(t *testing.T) {
+	h := newTestHandler()
+	names, msg := h.parseCommand("/cc write a function")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude] from /cc alias, got %v", names)
+	}
+	if msg != "write a function" {
+		t.Errorf("expected 'write a function', got %q", msg)
+	}
+}
+
+func TestParseCommand_CustomAlias(t *testing.T) {
+	h := newTestHandler()
+	h.customAliases = map[string]string{"ai": "claude", "c": "claude"}
+	names, msg := h.parseCommand("/ai hello")
+	if len(names) != 1 || names[0] != "claude" {
+		t.Errorf("expected [claude] from custom alias, got %v", names)
+	}
+	if msg != "hello" {
+		t.Errorf("expected 'hello', got %q", msg)
+	}
+}
+
+func TestResolveAlias(t *testing.T) {
+	h := newTestHandler()
+	tests := map[string]string{
+		"cc":  "claude",
+		"cx":  "codex",
+		"oc":  "openclaw",
+		"cs":  "cursor",
+		"km":  "kimi",
+		"gm":  "gemini",
+		"ocd": "opencode",
+	}
+	for alias, want := range tests {
+		got := h.resolveAlias(alias)
+		if got != want {
+			t.Errorf("resolveAlias(%q) = %q, want %q", alias, got, want)
+		}
+	}
+	if got := h.resolveAlias("unknown"); got != "unknown" {
+		t.Errorf("resolveAlias(unknown) = %q, want %q", got, "unknown")
+	}
+	h.customAliases = map[string]string{"cc": "custom-claude"}
+	if got := h.resolveAlias("cc"); got != "custom-claude" {
+		t.Errorf("resolveAlias(cc) with custom = %q, want custom-claude", got)
+	}
+}
+
+func TestBuildHelpText(t *testing.T) {
+	text := buildHelpText()
+	if text == "" {
+		t.Error("help text is empty")
+	}
+	if !strings.Contains(text, "/info") {
+		t.Error("help text should mention /info")
+	}
+	if !strings.Contains(text, "/help") {
+		t.Error("help text should mention /help")
+	}
+}

--- a/messaging/media_test.go
+++ b/messaging/media_test.go
@@ -1,0 +1,73 @@
+package messaging
+
+import "testing"
+
+func TestExtractImageURLs(t *testing.T) {
+	text := "check ![img](https://example.com/a.png) and ![](https://example.com/b.jpg)"
+	urls := ExtractImageURLs(text)
+	if len(urls) != 2 {
+		t.Fatalf("expected 2 urls, got %d", len(urls))
+	}
+	if urls[0] != "https://example.com/a.png" {
+		t.Errorf("urls[0] = %q", urls[0])
+	}
+	if urls[1] != "https://example.com/b.jpg" {
+		t.Errorf("urls[1] = %q", urls[1])
+	}
+}
+
+func TestExtractImageURLs_NoImages(t *testing.T) {
+	urls := ExtractImageURLs("just plain text")
+	if len(urls) != 0 {
+		t.Errorf("expected 0 urls, got %d", len(urls))
+	}
+}
+
+func TestExtractImageURLs_RelativeURL(t *testing.T) {
+	text := "![img](./local.png)"
+	urls := ExtractImageURLs(text)
+	if len(urls) != 0 {
+		t.Errorf("expected 0 urls for relative path, got %d", len(urls))
+	}
+}
+
+func TestFilenameFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://example.com/photo.png", "photo.png"},
+		{"https://example.com/path/to/report.pdf", "report.pdf"},
+		{"https://example.com/file", "file"},
+	}
+	for _, tt := range tests {
+		got := filenameFromURL(tt.url)
+		if got != tt.want {
+			t.Errorf("filenameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestFilenameFromURL_WithQuery(t *testing.T) {
+	got := filenameFromURL("https://example.com/photo.png?token=abc")
+	if got != "photo.png" {
+		t.Errorf("got %q, want %q", got, "photo.png")
+	}
+}
+
+func TestStripQuery(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://example.com/a?b=c", "https://example.com/a"},
+		{"https://example.com/a", "https://example.com/a"},
+		{"https://example.com/?x=1&y=2", "https://example.com/"},
+	}
+	for _, tt := range tests {
+		got := stripQuery(tt.input)
+		if got != tt.want {
+			t.Errorf("stripQuery(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Changes

### CI Pipeline (`.github/workflows/ci.yml` — new)
- **Test job**: Runs `go build` + `go test -race` on every push and PR
- **Build job**: Cross-compiles for 6 platforms (darwin/linux/windows x amd64/arm64)
- **Publish job**: Creates pre-release builds
  - Feature branches → `alpha-<branch>` pre-release
  - Main branch → `beta-latest` pre-release
  - Tags → formal release (existing `release.yml`)

### Release Workflow Upgrade (`.github/workflows/release.yml`)
- Added `windows/arm64` build target (was missing)
- Added `-trimpath` flag for reproducible builds
- Simplified Windows extension handling

### Messaging Tests (messaging package had **zero** tests)

**`messaging/handler_test.go`** — 10 test cases:
- `parseCommand`: no prefix, slash, @ prefix, multi-agent, dedup, switch-only, alias, custom alias
- `resolveAlias`: all built-in aliases, unknown passthrough, custom alias priority
- `buildHelpText`: non-empty, contains expected commands

**`messaging/media_test.go`** — 7 test cases:
- `ExtractImageURLs`: multiple images, no images, relative URL filtering
- `filenameFromURL`: basic paths, nested paths, query string stripping
- `stripQuery`: with/without query params

All tests pass locally (`go test ./... -count=1 -race`).