### PR TITLE
Support sending local agent artifacts as attachments

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -110,6 +110,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// Populate agent metas for /status
 	var metas []messaging.AgentMeta
+	workDirs := make(map[string]string, len(cfg.Agents))
 	for name, agCfg := range cfg.Agents {
 		command := agCfg.Command
 		if agCfg.Type == "http" {
@@ -121,8 +122,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 			Command: command,
 			Model:   agCfg.Model,
 		})
+		if agCfg.Cwd != "" {
+			workDirs[name] = agCfg.Cwd
+		}
 	}
 	handler.SetAgentMetas(metas)
+	handler.SetAgentWorkDirs(workDirs)
 
 	// Load custom aliases from agent configs
 	handler.SetCustomAliases(config.BuildAliasMap(cfg.Agents))

--- a/messaging/attachment.go
+++ b/messaging/attachment.go
@@ -1,0 +1,127 @@
+package messaging
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+var supportedAttachmentExts = []string{
+	".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+	".zip", ".txt", ".csv",
+	".png", ".jpg", ".jpeg", ".gif", ".webp",
+	".mp4", ".mov",
+}
+
+func defaultAttachmentWorkspace() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Clean(os.TempDir())
+	}
+	return filepath.Join(home, ".weclaw", "workspace")
+}
+
+func extractLocalAttachmentPaths(text string) []string {
+	var paths []string
+	seen := make(map[string]struct{})
+
+	for _, line := range strings.Split(text, "\n") {
+		candidate := strings.TrimSpace(line)
+		if candidate == "" || !filepath.IsAbs(candidate) {
+			continue
+		}
+		if !isSupportedAttachmentPath(candidate) {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		paths = append(paths, candidate)
+	}
+
+	return paths
+}
+
+func isAllowedAttachmentPath(path string, allowedRoots []string) bool {
+	cleanPath, err := canonicalizePath(path, true)
+	if err != nil {
+		return false
+	}
+
+	for _, root := range allowedRoots {
+		if root == "" {
+			continue
+		}
+		cleanRoot, err := canonicalizePath(root, false)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(cleanRoot, cleanPath)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func rewriteReplyWithAttachmentResults(reply string, sentPaths, failedPaths []string) string {
+	sentMap := make(map[string]string, len(sentPaths))
+	for _, path := range sentPaths {
+		sentMap[path] = "已发送附件：" + filepath.Base(path)
+	}
+
+	lines := strings.Split(reply, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if replacement, ok := sentMap[trimmed]; ok {
+			lines[i] = replacement
+		}
+	}
+
+	rewritten := strings.Join(lines, "\n")
+
+	var failureLines []string
+	seenFailures := make(map[string]struct{})
+	for _, path := range failedPaths {
+		if _, ok := seenFailures[path]; ok {
+			continue
+		}
+		seenFailures[path] = struct{}{}
+		failureLines = append(failureLines, "附件发送失败："+filepath.Base(path))
+	}
+	if len(failureLines) == 0 {
+		return rewritten
+	}
+	if strings.TrimSpace(rewritten) == "" {
+		return strings.Join(failureLines, "\n")
+	}
+	return rewritten + "\n" + strings.Join(failureLines, "\n")
+}
+
+func isSupportedAttachmentPath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return slices.Contains(supportedAttachmentExts, ext)
+}
+
+func canonicalizePath(path string, mustExist bool) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if realPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		return filepath.Clean(realPath), nil
+	} else if mustExist {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
+}

--- a/messaging/attachment_test.go
+++ b/messaging/attachment_test.go
@@ -1,0 +1,100 @@
+package messaging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractLocalAttachmentPaths(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "report.pdf")
+	txtPath := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(pdfPath, []byte("pdf"), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	if err := os.WriteFile(txtPath, []byte("txt"), 0o644); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+
+	reply := strings.Join([]string{
+		"这里是内联路径，不应该命中 " + pdfPath,
+		pdfPath,
+		"1. " + txtPath,
+		txtPath,
+		"file://" + pdfPath,
+		filepath.Join(dir, "missing.pdf"),
+		filepath.Join(dir, "folder"),
+	}, "\n")
+
+	got := extractLocalAttachmentPaths(reply)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 paths, got %d (%v)", len(got), got)
+	}
+	if got[0] != pdfPath {
+		t.Fatalf("got[0] = %q, want %q", got[0], pdfPath)
+	}
+	if got[1] != txtPath {
+		t.Fatalf("got[1] = %q, want %q", got[1], txtPath)
+	}
+}
+
+func TestIsAllowedAttachmentPath(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	otherRoot := filepath.Join(t.TempDir(), "other")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.MkdirAll(otherRoot, 0o755); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+
+	allowedPath := filepath.Join(workspaceRoot, "artifacts", "report.pdf")
+	deniedPath := filepath.Join(otherRoot, "report.pdf")
+	if err := os.MkdirAll(filepath.Dir(allowedPath), 0o755); err != nil {
+		t.Fatalf("mkdir allowed dir: %v", err)
+	}
+	if err := os.WriteFile(allowedPath, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write allowed file: %v", err)
+	}
+	if err := os.WriteFile(deniedPath, []byte("no"), 0o644); err != nil {
+		t.Fatalf("write denied file: %v", err)
+	}
+
+	if !isAllowedAttachmentPath(allowedPath, []string{workspaceRoot}) {
+		t.Fatalf("expected %q to be allowed", allowedPath)
+	}
+	if isAllowedAttachmentPath(deniedPath, []string{workspaceRoot}) {
+		t.Fatalf("expected %q to be denied", deniedPath)
+	}
+}
+
+func TestRewriteReplyWithAttachmentResults(t *testing.T) {
+	sentPath := "/tmp/report.pdf"
+	failedPath := "/tmp/archive.zip"
+	reply := strings.Join([]string{
+		"已生成文件：",
+		sentPath,
+		"这里再次内联提到 " + sentPath + "，不应该被替换。",
+		failedPath,
+	}, "\n")
+
+	got := rewriteReplyWithAttachmentResults(reply, []string{sentPath}, []string{failedPath})
+
+	if strings.Contains(got, "\n"+sentPath+"\n") {
+		t.Fatalf("expected sent path line to be replaced, got %q", got)
+	}
+	if !strings.Contains(got, "已发送附件：report.pdf") {
+		t.Fatalf("expected sent replacement, got %q", got)
+	}
+	if !strings.Contains(got, "这里再次内联提到 "+sentPath+"，不应该被替换。") {
+		t.Fatalf("expected inline path to remain, got %q", got)
+	}
+	if !strings.Contains(got, failedPath) {
+		t.Fatalf("expected failed path to remain, got %q", got)
+	}
+	if !strings.Contains(got, "附件发送失败：archive.zip") {
+		t.Fatalf("expected failure note, got %q", got)
+	}
+}

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -35,6 +35,7 @@ type Handler struct {
 	defaultName   string
 	agents        map[string]agent.Agent // name -> running agent
 	agentMetas    []AgentMeta            // all configured agents (for /status)
+	agentWorkDirs map[string]string      // agent name -> configured/runtime cwd
 	customAliases map[string]string      // custom alias -> agent name (from config)
 	factory       AgentFactory
 	saveDefault   SaveDefaultFunc
@@ -46,9 +47,10 @@ type Handler struct {
 // NewHandler creates a new message handler.
 func NewHandler(factory AgentFactory, saveDefault SaveDefaultFunc) *Handler {
 	return &Handler{
-		agents:      make(map[string]agent.Agent),
-		factory:     factory,
-		saveDefault: saveDefault,
+		agents:        make(map[string]agent.Agent),
+		agentWorkDirs: make(map[string]string),
+		factory:       factory,
+		saveDefault:   saveDefault,
 	}
 }
 
@@ -80,6 +82,17 @@ func (h *Handler) SetAgentMetas(metas []AgentMeta) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.agentMetas = metas
+}
+
+// SetAgentWorkDirs sets the configured working directory for each agent.
+func (h *Handler) SetAgentWorkDirs(workDirs map[string]string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.agentWorkDirs = make(map[string]string, len(workDirs))
+	for name, dir := range workDirs {
+		h.agentWorkDirs[name] = dir
+	}
 }
 
 // SetDefaultAgent sets the default agent (already started).
@@ -403,6 +416,10 @@ func (h *Handler) sendToDefaultAgent(ctx context.Context, client *ilink.Client, 
 		}
 	}()
 
+	h.mu.RLock()
+	defaultName := h.defaultName
+	h.mu.RUnlock()
+
 	ag := h.getDefaultAgent()
 	var reply string
 	if ag != nil {
@@ -416,7 +433,7 @@ func (h *Handler) sendToDefaultAgent(ctx context.Context, client *ilink.Client, 
 		reply = "[echo] " + text
 	}
 
-	h.sendReplyWithMedia(ctx, client, msg, reply, clientID)
+	h.sendReplyWithMedia(ctx, client, msg, defaultName, reply, clientID)
 }
 
 // sendToNamedAgent sends the message to a specific agent and replies.
@@ -433,7 +450,7 @@ func (h *Handler) sendToNamedAgent(ctx context.Context, client *ilink.Client, ms
 	if err != nil {
 		reply = fmt.Sprintf("Error: %v", err)
 	}
-	h.sendReplyWithMedia(ctx, client, msg, reply, clientID)
+	h.sendReplyWithMedia(ctx, client, msg, name, reply, clientID)
 }
 
 // broadcastToAgents sends the message to multiple agents in parallel.
@@ -467,13 +484,33 @@ func (h *Handler) broadcastToAgents(ctx context.Context, client *ilink.Client, m
 		r := <-ch
 		reply := fmt.Sprintf("[%s] %s", r.name, r.reply)
 		clientID := NewClientID()
-		h.sendReplyWithMedia(ctx, client, msg, reply, clientID)
+		h.sendReplyWithMedia(ctx, client, msg, r.name, reply, clientID)
 	}
 }
 
 // sendReplyWithMedia sends a text reply and any extracted image URLs.
-func (h *Handler) sendReplyWithMedia(ctx context.Context, client *ilink.Client, msg ilink.WeixinMessage, reply, clientID string) {
+func (h *Handler) sendReplyWithMedia(ctx context.Context, client *ilink.Client, msg ilink.WeixinMessage, agentName, reply, clientID string) {
 	imageURLs := ExtractImageURLs(reply)
+	attachmentPaths := extractLocalAttachmentPaths(reply)
+	allowedRoots := h.allowedAttachmentRoots(agentName)
+
+	var sentPaths []string
+	var failedPaths []string
+	for _, attachmentPath := range attachmentPaths {
+		if !isAllowedAttachmentPath(attachmentPath, allowedRoots) {
+			log.Printf("[handler] rejected attachment outside allowed roots for agent %q: %s", agentName, attachmentPath)
+			failedPaths = append(failedPaths, attachmentPath)
+			continue
+		}
+		if err := SendMediaFromPath(ctx, client, msg.FromUserID, attachmentPath, msg.ContextToken); err != nil {
+			log.Printf("[handler] failed to send attachment to %s: %v", msg.FromUserID, err)
+			failedPaths = append(failedPaths, attachmentPath)
+			continue
+		}
+		sentPaths = append(sentPaths, attachmentPath)
+	}
+
+	reply = rewriteReplyWithAttachmentResults(reply, sentPaths, failedPaths)
 
 	if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
 		log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
@@ -484,6 +521,20 @@ func (h *Handler) sendReplyWithMedia(ctx context.Context, client *ilink.Client, 
 			log.Printf("[handler] failed to send image to %s: %v", msg.FromUserID, err)
 		}
 	}
+}
+
+func (h *Handler) allowedAttachmentRoots(agentName string) []string {
+	roots := []string{defaultAttachmentWorkspace()}
+
+	h.mu.RLock()
+	agentDir := h.agentWorkDirs[agentName]
+	h.mu.RUnlock()
+
+	if agentDir != "" {
+		roots = append(roots, agentDir)
+	}
+
+	return roots
 }
 
 // chatWithAgent sends a message to an agent and returns the reply, with logging.
@@ -604,6 +655,12 @@ func (h *Handler) handleCwd(trimmed string) string {
 		ag.SetCwd(absPath)
 		log.Printf("[handler] updated cwd for agent %s: %s", name, absPath)
 	}
+
+	h.mu.Lock()
+	for name := range agents {
+		h.agentWorkDirs[name] = absPath
+	}
+	h.mu.Unlock()
 
 	return fmt.Sprintf("cwd: %s", absPath)
 }

--- a/messaging/media.go
+++ b/messaging/media.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"mime"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -33,31 +34,44 @@ func ExtractImageURLs(text string) []string {
 
 // SendMediaFromURL downloads a file from a URL and sends it as a media message.
 func SendMediaFromURL(ctx context.Context, client *ilink.Client, toUserID, mediaURL, contextToken string) error {
-	// Download the file
 	data, contentType, err := downloadFile(ctx, mediaURL)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", mediaURL, err)
 	}
 
-	// Determine media type and item type
-	cdnMediaType, itemType := classifyMedia(contentType, mediaURL)
+	return sendMediaData(ctx, client, toUserID, filenameFromURL(mediaURL), mediaURL, data, contentType, contextToken)
+}
 
-	log.Printf("[media] uploading %s (%s, %d bytes) for %s", mediaURL, contentType, len(data), toUserID)
+// SendMediaFromPath reads a local file and sends it as a media message.
+func SendMediaFromPath(ctx context.Context, client *ilink.Client, toUserID, path, contextToken string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
 
-	// Upload to CDN
+	return sendMediaData(ctx, client, toUserID, filepath.Base(path), path, data, inferContentType(path), contextToken)
+}
+
+func sendMediaData(ctx context.Context, client *ilink.Client, toUserID, fileName, source string, data []byte, contentType, contextToken string) error {
+	if fileName == "" {
+		fileName = "file"
+	}
+
+	cdnMediaType, itemType := classifyMedia(contentType, source)
+
+	log.Printf("[media] uploading %s (%s, %d bytes) for %s", source, contentType, len(data), toUserID)
+
 	uploaded, err := UploadFileToCDN(ctx, client, data, toUserID, cdnMediaType)
 	if err != nil {
 		return fmt.Errorf("upload to CDN: %w", err)
 	}
 
-	// Build media info
 	media := &ilink.MediaInfo{
 		EncryptQueryParam: uploaded.DownloadParam,
 		AESKey:            AESKeyToBase64(uploaded.AESKeyHex),
 		EncryptType:       1,
 	}
 
-	// Build message item based on type
 	var item ilink.MessageItem
 	switch itemType {
 	case ilink.ItemTypeImage:
@@ -77,7 +91,6 @@ func SendMediaFromURL(ctx context.Context, client *ilink.Client, toUserID, media
 			},
 		}
 	default:
-		fileName := filenameFromURL(mediaURL)
 		item = ilink.MessageItem{
 			Type: ilink.ItemTypeFile,
 			FileItem: &ilink.FileItem{
@@ -88,7 +101,6 @@ func SendMediaFromURL(ctx context.Context, client *ilink.Client, toUserID, media
 		}
 	}
 
-	// Send the media message
 	req := &ilink.SendMessageRequest{
 		Msg: ilink.SendMsg{
 			FromUserID:   client.BotID(),
@@ -110,7 +122,7 @@ func SendMediaFromURL(ctx context.Context, client *ilink.Client, toUserID, media
 		return fmt.Errorf("send media failed: ret=%d errmsg=%s", resp.Ret, resp.ErrMsg)
 	}
 
-	log.Printf("[media] sent %s to %s", contentType, toUserID)
+	log.Printf("[media] sent %s to %s from %s", contentType, toUserID, source)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add local attachment parsing and whitelist checks for agent reply text
- send local files from `~/.weclaw/workspace` or the current agent cwd back to WeChat as attachments
- keep existing URL-based media sending behavior unchanged

## Testing
- added unit tests for attachment path extraction, whitelist checks, and reply rewriting
- not run locally in this environment because Go is not installed on the machine
