### PR TITLE
Fix Windows support: platform-abstract process lifecycle, binary update, and install script

### DIFF
--- a/cmd/proc_unix.go
+++ b/cmd/proc_unix.go
@@ -3,10 +3,33 @@
 package cmd
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
 )
 
+func notifyContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+}
+
 func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func processExists(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+func signalTerminate(p *os.Process) error {
+	return p.Signal(syscall.SIGTERM)
+}
+
+func killByName(exePath string) {
+	_ = exec.Command("pkill", "-f", exePath+" start").Run()
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -2,8 +2,36 @@
 
 package cmd
 
-import "os/exec"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+)
+
+func notifyContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, os.Interrupt)
+}
 
 func setSysProcAttr(_ *exec.Cmd) {
 	// No Setsid on Windows — process is already detached via Start()
+}
+
+func processExists(pid int) bool {
+	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), fmt.Sprintf("%d", pid))
+}
+
+func signalTerminate(p *os.Process) error {
+	return p.Kill()
+}
+
+func killByName(exePath string) {
+	_ = exec.Command("taskkill", "/F", "/IM", filepath.Base(exePath)).Run()
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,7 +21,7 @@ var restartCmd = &cobra.Command{
 		if err == nil && processExists(pid) {
 			fmt.Printf("Stopping weclaw (pid=%d)...\n", pid)
 			if p, err := os.FindProcess(pid); err == nil {
-				p.Signal(syscall.SIGTERM)
+				_ = signalTerminate(p)
 			}
 			for i := 0; i < 20; i++ {
 				if !processExists(pid) {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,10 +6,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/fastclaw-ai/weclaw/agent"
@@ -44,7 +42,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		accounts, _ := ilink.LoadAllCredentials()
 		if len(accounts) == 0 {
 			fmt.Println("No WeChat accounts found, starting login...")
-			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			ctx, cancel := notifyContext(context.Background())
 			_, err := doLogin(ctx)
 			cancel()
 			if err != nil {
@@ -54,7 +52,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return runDaemon()
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := notifyContext(context.Background())
 	defer cancel()
 
 	// Load all accounts
@@ -405,21 +403,12 @@ func readPid() (int, error) {
 	return pid, nil
 }
 
-func processExists(pid int) bool {
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// Signal 0 checks if process exists without killing it
-	return p.Signal(syscall.Signal(0)) == nil
-}
-
 // stopAllWeclaw kills all running weclaw processes (by PID file and by process scan).
 func stopAllWeclaw() {
 	// 1. Kill by PID file
 	if pid, err := readPid(); err == nil && processExists(pid) {
 		if p, err := os.FindProcess(pid); err == nil {
-			_ = p.Signal(syscall.SIGTERM)
+			_ = signalTerminate(p)
 		}
 	}
 	os.Remove(pidFile())
@@ -429,7 +418,6 @@ func stopAllWeclaw() {
 	if err != nil {
 		return
 	}
-	// Use pkill to kill all processes matching the executable path
-	_ = exec.Command("pkill", "-f", exe+" start").Run()
+	killByName(exe)
 	time.Sleep(500 * time.Millisecond)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -122,23 +121,27 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func getLatestVersion() (string, error) {
-	resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", githubRepo))
+	// Use HTTP redirect instead of API to avoid rate limits
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(fmt.Sprintf("https://github.com/%s/releases/latest", githubRepo))
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		return "", fmt.Errorf("no redirect from GitHub releases/latest")
 	}
-
-	var release struct {
-		TagName string `json:"tag_name"`
+	parts := strings.Split(loc, "/tag/")
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("unexpected redirect URL: %s", loc)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
-	}
-	return release.TagName, nil
+	return parts[1], nil
 }
 
 func downloadFile(url string) (string, error) {
@@ -178,17 +181,29 @@ func replaceBinary(src, dst string) error {
 		return nil
 	}
 
-	// Try with sudo on Unix
-	if runtime.GOOS != "windows" {
-		fmt.Printf("Installing to %s (requires sudo)...\n", dst)
-		cmd := exec.Command("sudo", "cp", src, dst)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
+	if runtime.GOOS == "windows" {
+		// On Windows the running binary is locked. Move it aside first,
+		// then place the new binary. The old file will be cleaned up on
+		// next restart or can be deleted manually.
+		old := dst + ".old"
+		os.Remove(old)
+		if err := os.Rename(dst, old); err != nil {
+			return fmt.Errorf("cannot move old binary aside: %w", err)
+		}
+		if err := os.Rename(src, dst); err != nil {
+			os.Rename(old, dst)
+			return fmt.Errorf("cannot install new binary: %w", err)
+		}
+		return nil
 	}
 
-	return fmt.Errorf("cannot write to %s", dst)
+	// Try with sudo on Unix
+	fmt.Printf("Installing to %s (requires sudo)...\n", dst)
+	cmd := exec.Command("sudo", "cp", src, dst)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func resolveSymlink(path string) (string, error) {

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,81 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install weclaw on Windows.
+.DESCRIPTION
+    Downloads the latest weclaw release from GitHub and installs it
+    to $env:LOCALAPPDATA\weclaw. Adds the directory to the user PATH
+    if not already present.
+#>
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "fastclaw-ai/weclaw"
+$Binary = "weclaw"
+$InstallDir = "$env:LOCALAPPDATA\weclaw"
+
+# Detect architecture
+$Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64" { "amd64" }
+    "ARM64" { "arm64" }
+    default { Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"; exit 1 }
+}
+
+Write-Host "Detected: windows/$Arch"
+
+# Get latest version via redirect
+Write-Host "Fetching latest release..."
+try {
+    $Response = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" `
+        -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
+} catch {
+    $Response = $_.Exception.Response
+}
+
+$Location = if ($Response.Headers["Location"]) {
+    $Response.Headers["Location"]
+} elseif ($Response.Headers.Location) {
+    $Response.Headers.Location
+} else {
+    $null
+}
+
+if (-not $Location) {
+    Write-Error "Could not determine latest version. Is there a release on GitHub?"
+    exit 1
+}
+
+$Version = ($Location -split "/tag/")[-1].Trim()
+Write-Host "Latest version: $Version"
+
+# Download
+$Filename = "${Binary}_windows_${Arch}.exe"
+$Url = "https://github.com/$Repo/releases/download/$Version/$Filename"
+
+Write-Host "Downloading $Url..."
+$TmpFile = Join-Path $env:TEMP $Filename
+
+Invoke-WebRequest -Uri $Url -OutFile $TmpFile -UseBasicParsing
+
+# Install
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+$DestPath = Join-Path $InstallDir "$Binary.exe"
+Move-Item -Path $TmpFile -Destination $DestPath -Force
+
+# Add to PATH if not already present
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    Write-Host ""
+    Write-Host "Added $InstallDir to user PATH."
+    Write-Host "Please restart your terminal for PATH changes to take effect."
+}
+
+Write-Host ""
+Write-Host "weclaw $Version installed to $DestPath"
+Write-Host ""
+Write-Host "Get started:"
+Write-Host "  weclaw start"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ echo "Detected: ${OS}/${ARCH}"
 
 # Get latest version
 echo "Fetching latest release..."
-VERSION=$(curl -fsSL -H "User-Agent: weclaw-installer" "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p')
+VERSION=$(curl -fsSI "https://github.com/${REPO}/releases/latest" | grep -i '^location:' | sed 's|.*/tag/||' | tr -d '\r')
 
 if [ -z "$VERSION" ]; then
   echo "Error: could not determine latest version. Is there a release on GitHub?"


### PR DESCRIPTION
## Problem

WeClaw builds for Windows (`windows/amd64`, `windows/arm64`) in CI, but several core functions **fail at runtime or compile-time** on Windows:

| Issue | Location | Impact |
|-------|----------|--------|
| `syscall.SIGINT, syscall.SIGTERM` in `signal.NotifyContext` | `start.go` | `SIGTERM` does not exist on Windows — **compilation fails** or behavior is undefined |
| `Signal(0)` for process detection | `start.go` `processExists()` | On Windows `Signal(0)` always returns `nil` — **process detection never works** |
| `syscall.SIGTERM` for process termination | `start.go` `stopAllWeclaw()`, `restart.go` | Windows has no SIGTERM — **process termination silently fails** |
| `pkill -f` for cleanup | `start.go` `stopAllWeclaw()` | Windows has no `pkill` — **orphan cleanup never works** |
| `replaceBinary()` rename | `update.go` | Running `.exe` is file-locked on Windows — **`weclaw update` always fails** |
| `getLatestVersion()` uses GitHub API | `update.go` | Anonymous rate limit (60/hr) — **fails in CI or with frequent checks** |
| No Windows install script | — | Users must manually download and configure PATH |

## Solution

### 1. Platform abstraction via build tags (`proc_unix.go` / `proc_windows.go`)

Move all platform-specific logic into build-tagged files. The existing files only had `setSysProcAttr` — now they also provide:

| Function | Unix | Windows |
|----------|------|---------|
| `notifyContext()` | `SIGINT + SIGTERM` | `os.Interrupt` |
| `processExists()` | `Signal(0)` | `tasklist /FI "PID eq X"` |
| `signalTerminate()` | `SIGTERM` | `Kill()` (hard kill) |
| `killByName()` | `pkill -f` | `taskkill /F /IM` |

### 2. Remove `syscall` from shared code

`start.go` and `restart.go` no longer import `syscall`. All platform calls go through the abstracted functions above.

### 3. `replaceBinary()` — Windows file-lock handling

On Windows, a running `.exe` cannot be overwritten. The new logic:
1. Rename current binary to `.old`
2. Place new binary at original path
3. If step 2 fails, restore `.old` back

### 4. `getLatestVersion()` — avoid GitHub API rate limits

Replace `api.github.com/repos/.../releases/latest` (JSON, 60 req/hr anonymous limit) with HTTP redirect from `github.com/.../releases/latest` (no rate limit, no JSON parsing).

### 5. `install.ps1` — Windows installer

New PowerShell install script that:
- Detects architecture (amd64/arm64)
- Downloads latest release via redirect
- Installs to `$env:LOCALAPPDATA\weclaw`
- Adds to user PATH if not present

## Files Changed

- `cmd/proc_unix.go` — Added `notifyContext`, `processExists`, `signalTerminate`, `killByName`
- `cmd/proc_windows.go` — Added Windows-specific implementations for all 5 platform functions
- `cmd/start.go` — Removed `syscall` import; use `notifyContext`, `signalTerminate`, `killByName`
- `cmd/restart.go` — Removed `syscall` import; use `signalTerminate`
- `cmd/update.go` — `getLatestVersion` via redirect; `replaceBinary` with Windows file-lock handling
- `install.ps1` — New Windows installer script

## Testing

- `go build ./...` passes (darwin)
- `GOOS=windows GOARCH=amd64 go build ./...` passes (cross-compile)
- `go test -race ./...` all pass