### PR TITLE
Add cron scheduler and heartbeat runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Send these as WeChat messages:
 | `/claude` | Switch default agent to Claude |
 | `/cwd /path/to/project` | Switch workspace directory |
 | `/new` | Start a new conversation (clear session) |
+| `/cron list\|add\|delete\|enable\|disable` | Manage scheduled tasks |
 | `/info` | Show current agent info |
 | `/help` | Show help message |
 
@@ -151,6 +152,68 @@ Supported media types: images (png, jpg, gif, webp), videos (mp4, mov), files (p
 
 Set `WECLAW_API_ADDR` to change the listen address (e.g. `0.0.0.0:18011`).
 
+## Cron (Scheduled Tasks)
+
+Schedule recurring or one-shot tasks that send messages to AI agents on a timer:
+
+```
+/cron add "standup" every:24h "summarize yesterday's work"
+/cron add "check" */30 * * * * "check for new PRs"
+/cron add "reminder" at:2026-04-01T09:00:00 "sprint review today"
+/cron list
+/cron enable <id>
+/cron disable <id>
+/cron delete <id>
+```
+
+**Schedule formats:**
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| `every:<duration>` | `every:5m`, `every:24h` | Fixed interval |
+| Cron expression | `*/30 * * * *`, `0 9 * * 1-5` | Standard 5-field cron |
+| `at:<time>` | `at:2026-04-01T09:00:00` | One-shot (auto-disables after run) |
+
+Jobs are persisted to `~/.weclaw/cron/jobs.json` and survive restarts. Each job can optionally target a specific agent.
+
+## Heartbeat
+
+Periodic agent check-in driven by a user-authored checklist. Create `~/.weclaw/HEARTBEAT.md`:
+
+```markdown
+# Heartbeat checklist
+- Check if any urgent emails arrived
+- Scan for open PRs needing review
+- Check CI pipeline status
+```
+
+WeClaw reads this file on each heartbeat interval, sends it to the default agent, and:
+- Agent replies `HEARTBEAT_OK` → suppressed (nothing to report)
+- Agent replies with content → delivered to the target user with `[Heartbeat]` prefix
+- Duplicate replies within 24h are suppressed to avoid noise
+
+**Config:**
+
+```json
+{
+  "heartbeat": {
+    "enabled": true,
+    "interval": "30m",
+    "active_hours": "09:00-18:00",
+    "timezone": "Asia/Shanghai",
+    "target_user": "your_wechat_user_id"
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable heartbeat runner |
+| `interval` | `30m` | Time between heartbeat checks |
+| `active_hours` | — | Only run during these hours (e.g. `09:00-18:00`) |
+| `timezone` | local | IANA timezone for active hours |
+| `target_user` | — | WeChat user ID to send heartbeat results to |
+
 ## Configuration
 
 Config file: `~/.weclaw/config.json`
@@ -180,6 +243,13 @@ Config file: `~/.weclaw/config.json`
       "api_key": "sk-xxx",
       "model": "openclaw:main"
     }
+  },
+  "heartbeat": {
+    "enabled": true,
+    "interval": "30m",
+    "active_hours": "09:00-18:00",
+    "timezone": "Asia/Shanghai",
+    "target_user": "your_wechat_user_id"
   }
 }
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,6 +67,7 @@ docker run -it -v ~/.weclaw:/root/.weclaw ghcr.io/fastclaw-ai/weclaw start
 | `/claude`               | 切换默认 Agent 为 Claude |
 | `/cwd /path/to/project` | 切换工作目录             |
 | `/new`                  | 开始新对话（清除会话）   |
+| `/cron list\|add\|delete\|enable\|disable` | 管理定时任务 |
 | `/info`                 | 查看当前 Agent 信息      |
 | `/help`                 | 查看帮助信息             |
 
@@ -152,6 +153,68 @@ curl -X POST http://127.0.0.1:18011/api/send \
 
 设置 `WECLAW_API_ADDR` 环境变量可更改监听地址（如 `0.0.0.0:18011`）。
 
+## 定时任务（Cron）
+
+在聊天中管理定时或一次性任务，定时发消息给 AI Agent 执行：
+
+```
+/cron add "standup" every:24h "总结昨天的工作"
+/cron add "check" */30 * * * * "检查新的 PR"
+/cron add "reminder" at:2026-04-01T09:00:00 "今天下午 Sprint 评审"
+/cron list
+/cron enable <id>
+/cron disable <id>
+/cron delete <id>
+```
+
+**调度格式：**
+
+| 格式 | 示例 | 说明 |
+|------|------|------|
+| `every:<时长>` | `every:5m`、`every:24h` | 固定间隔 |
+| Cron 表达式 | `*/30 * * * *`、`0 9 * * 1-5` | 标准 5 字段 cron |
+| `at:<时间>` | `at:2026-04-01T09:00:00` | 一次性（执行后自动禁用） |
+
+任务持久化到 `~/.weclaw/cron/jobs.json`，重启不丢失。每个任务可选指定目标 Agent。
+
+## 心跳（Heartbeat）
+
+基于用户编写的检查清单，定时让 Agent 做自主巡检。创建 `~/.weclaw/HEARTBEAT.md`：
+
+```markdown
+# 心跳检查清单
+- 检查是否有紧急邮件
+- 扫描需要 review 的 PR
+- 检查 CI 流水线状态
+```
+
+WeClaw 每次心跳间隔读取此文件，发给默认 Agent：
+- Agent 回复 `HEARTBEAT_OK` → 吞掉（一切正常）
+- Agent 回复有内容 → 以 `[Heartbeat]` 前缀发送给目标用户
+- 24 小时内重复回复自动去重
+
+**配置：**
+
+```json
+{
+  "heartbeat": {
+    "enabled": true,
+    "interval": "30m",
+    "active_hours": "09:00-18:00",
+    "timezone": "Asia/Shanghai",
+    "target_user": "your_wechat_user_id"
+  }
+}
+```
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `enabled` | `false` | 启用心跳 |
+| `interval` | `30m` | 心跳间隔 |
+| `active_hours` | — | 仅在此时段运行（如 `09:00-18:00`） |
+| `timezone` | 本地 | 活跃时段的时区（IANA 格式） |
+| `target_user` | — | 接收心跳结果的微信用户 ID |
+
 ## 配置
 
 配置文件路径：`~/.weclaw/config.json`
@@ -181,6 +244,13 @@ curl -X POST http://127.0.0.1:18011/api/send \
       "api_key": "sk-xxx",
       "model": "openclaw:main"
     }
+  },
+  "heartbeat": {
+    "enabled": true,
+    "interval": "30m",
+    "active_hours": "09:00-18:00",
+    "timezone": "Asia/Shanghai",
+    "target_user": "your_wechat_user_id"
   }
 }
 ```

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -138,6 +138,44 @@ func runStart(cmd *cobra.Command, args []string) error {
 		log.Printf("Image save directory: %s", cfg.SaveDir)
 	}
 
+	// Initialize cron scheduler
+	cronStorePath, err := messaging.DefaultCronStorePath()
+	if err != nil {
+		log.Printf("Warning: failed to resolve cron store path: %v", err)
+	} else {
+		cronStore := messaging.NewCronStore(cronStorePath)
+		if err := cronStore.Load(); err != nil {
+			log.Printf("Warning: failed to load cron store: %v", err)
+		}
+		handler.SetCronStore(cronStore)
+
+		// Use the first account's client for sending cron messages
+		firstClient := ilink.NewClient(accounts[0])
+		targetUser := cfg.Heartbeat.TargetUser
+
+		cronScheduler := messaging.NewCronScheduler(cronStore, firstClient, targetUser, func(name string) agent.Agent {
+			if name == "" {
+				return handler.GetDefaultAgent()
+			}
+			ag, err := handler.GetAgent(ctx, name)
+			if err != nil {
+				return nil
+			}
+			return ag
+		})
+		go cronScheduler.Start(ctx)
+
+		// Start heartbeat runner
+		if cfg.Heartbeat.Enabled {
+			hbRunner, err := messaging.NewHeartbeatRunner(cfg.Heartbeat, firstClient, targetUser, handler.GetDefaultAgent)
+			if err != nil {
+				log.Printf("Warning: failed to start heartbeat runner: %v", err)
+			} else {
+				go hbRunner.Start(ctx)
+			}
+		}
+	}
+
 	// Start default agent initialization in background so monitors can start immediately
 	go func() {
 		if cfg.DefaultAgent == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,16 @@ type Config struct {
 	APIAddr      string                 `json:"api_addr,omitempty"`
 	SaveDir      string                 `json:"save_dir,omitempty"`
 	Agents       map[string]AgentConfig `json:"agents"`
+	Heartbeat    HeartbeatConfig        `json:"heartbeat,omitempty"`
+}
+
+// HeartbeatConfig holds heartbeat runner configuration.
+type HeartbeatConfig struct {
+	Enabled     bool   `json:"enabled"`
+	Interval    string `json:"interval,omitempty"`     // e.g. "30m"
+	ActiveHours string `json:"active_hours,omitempty"` // e.g. "09:00-18:00"
+	Timezone    string `json:"timezone,omitempty"`      // IANA timezone
+	TargetUser  string `json:"target_user,omitempty"`   // user ID to send heartbeat results to
 }
 
 // AgentConfig holds configuration for a single agent.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
 github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/messaging/cron.go
+++ b/messaging/cron.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fastclaw-ai/weclaw/agent"
@@ -21,6 +22,7 @@ type CronScheduler struct {
 	targetUser string // user ID to send cron results to
 	getAgent   func(name string) agent.Agent
 	cronParser cron.Parser
+	running    sync.Map // job ID -> struct{}, tracks in-flight jobs
 }
 
 // NewCronScheduler creates a scheduler.
@@ -80,7 +82,23 @@ func (s *CronScheduler) tick(ctx context.Context) {
 		if job.State.NextRunAt.IsZero() || now.Before(job.State.NextRunAt) {
 			continue
 		}
-		go s.executeJob(ctx, job)
+		// Skip if this job is already running
+		if _, loaded := s.running.LoadOrStore(job.ID, struct{}{}); loaded {
+			continue
+		}
+		// Advance NextRunAt immediately to prevent re-dispatch on next tick
+		state := job.State
+		next, err := s.computeNextRun(job.Schedule, now)
+		if err == nil {
+			state.NextRunAt = next
+		} else {
+			state.NextRunAt = now.Add(cronTickInterval * 2)
+		}
+		s.store.UpdateState(job.ID, state)
+		go func(j CronJob) {
+			defer s.running.Delete(j.ID)
+			s.executeJob(ctx, j)
+		}(job)
 	}
 }
 
@@ -94,7 +112,12 @@ func (s *CronScheduler) executeJob(ctx context.Context, job CronJob) {
 
 	ag := s.getAgent(job.Agent)
 	if ag == nil {
-		s.recordResult(job, "error", "no agent available")
+		log.Printf("[cron] no agent available for job %q, will retry", job.Name)
+		// Reschedule for next tick instead of recording an error,
+		// so one-shot (DeleteAfter) jobs are not permanently lost.
+		state := job.State
+		state.NextRunAt = time.Now().Add(cronTickInterval)
+		s.store.UpdateState(job.ID, state)
 		return
 	}
 

--- a/messaging/cron.go
+++ b/messaging/cron.go
@@ -1,0 +1,193 @@
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/fastclaw-ai/weclaw/agent"
+	"github.com/fastclaw-ai/weclaw/ilink"
+	"github.com/robfig/cron/v3"
+)
+
+const cronTickInterval = 30 * time.Second
+
+// CronScheduler runs cron jobs on schedule.
+type CronScheduler struct {
+	store      *CronStore
+	client     *ilink.Client
+	targetUser string // user ID to send cron results to
+	getAgent   func(name string) agent.Agent
+	cronParser cron.Parser
+}
+
+// NewCronScheduler creates a scheduler.
+func NewCronScheduler(store *CronStore, client *ilink.Client, targetUser string, getAgent func(name string) agent.Agent) *CronScheduler {
+	return &CronScheduler{
+		store:      store,
+		client:     client,
+		targetUser: targetUser,
+		getAgent:   getAgent,
+		cronParser: cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow),
+	}
+}
+
+// Start runs the scheduler loop.
+func (s *CronScheduler) Start(ctx context.Context) {
+	log.Println("[cron] scheduler started")
+	ticker := time.NewTicker(cronTickInterval)
+	defer ticker.Stop()
+
+	s.initNextRuns()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[cron] scheduler stopped")
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *CronScheduler) initNextRuns() {
+	now := time.Now()
+	for _, job := range s.store.List() {
+		if !job.Enabled || !job.State.NextRunAt.IsZero() {
+			continue
+		}
+		next, err := s.computeNextRun(job.Schedule, now)
+		if err != nil {
+			log.Printf("[cron] invalid schedule for job %q, disabling: %v", job.Name, err)
+			_ = s.store.SetEnabled(job.ID, false)
+			continue
+		}
+		state := job.State
+		state.NextRunAt = next
+		s.store.UpdateState(job.ID, state)
+	}
+}
+
+func (s *CronScheduler) tick(ctx context.Context) {
+	now := time.Now()
+	for _, job := range s.store.List() {
+		if !job.Enabled {
+			continue
+		}
+		if job.State.NextRunAt.IsZero() || now.Before(job.State.NextRunAt) {
+			continue
+		}
+		go s.executeJob(ctx, job)
+	}
+}
+
+func (s *CronScheduler) executeJob(ctx context.Context, job CronJob) {
+	log.Printf("[cron] executing job %q (%s)", job.Name, job.ID)
+
+	userID := job.UserID
+	if userID == "" {
+		userID = s.targetUser
+	}
+
+	ag := s.getAgent(job.Agent)
+	if ag == nil {
+		s.recordResult(job, "error", "no agent available")
+		return
+	}
+
+	conversationID := fmt.Sprintf("cron:%s", job.ID)
+	prompt := fmt.Sprintf("[Scheduled Task: %s]\n%s", job.Name, job.Message)
+
+	reply, err := ag.Chat(ctx, conversationID, prompt)
+	if err != nil {
+		log.Printf("[cron] agent error for job %q: %v", job.Name, err)
+		s.recordResult(job, "error", err.Error())
+		return
+	}
+
+	reply = strings.TrimSpace(reply)
+	if reply != "" && s.client != nil && userID != "" {
+		text := fmt.Sprintf("[Cron: %s] %s", job.Name, reply)
+		if err := SendTextReply(ctx, s.client, userID, text, "", ""); err != nil {
+			log.Printf("[cron] failed to send reply for job %q: %v", job.Name, err)
+			s.recordResult(job, "error", "send failed: "+err.Error())
+			return
+		}
+	}
+
+	s.recordResult(job, "ok", "")
+}
+
+func (s *CronScheduler) recordResult(job CronJob, status, errMsg string) {
+	state := job.State
+	state.LastRunAt = time.Now()
+	state.LastStatus = status
+	state.RunCount++
+	if status == "error" {
+		state.ErrorCount++
+		state.LastError = errMsg
+	} else {
+		state.LastError = ""
+	}
+
+	if state.DeleteAfter {
+		_ = s.store.SetEnabled(job.ID, false)
+	}
+
+	next, err := s.computeNextRun(job.Schedule, time.Now())
+	if err != nil {
+		_ = s.store.SetEnabled(job.ID, false)
+		log.Printf("[cron] cannot compute next run for %q, disabling: %v", job.Name, err)
+	} else {
+		state.NextRunAt = next
+	}
+
+	s.store.UpdateState(job.ID, state)
+}
+
+// computeNextRun calculates the next run time for a schedule string.
+func (s *CronScheduler) computeNextRun(schedule string, after time.Time) (time.Time, error) {
+	schedule = strings.TrimSpace(schedule)
+
+	// One-shot: "at:2026-04-01T09:00:00"
+	if strings.HasPrefix(schedule, "at:") {
+		t, err := time.Parse(time.RFC3339, strings.TrimPrefix(schedule, "at:"))
+		if err != nil {
+			t, err = time.ParseInLocation("2006-01-02T15:04:05", strings.TrimPrefix(schedule, "at:"), time.Local)
+			if err != nil {
+				return time.Time{}, fmt.Errorf("invalid at schedule: %w", err)
+			}
+		}
+		if t.Before(after) {
+			return time.Time{}, fmt.Errorf("at time %s is in the past", t)
+		}
+		return t, nil
+	}
+
+	// Interval: "every:5m"
+	if strings.HasPrefix(schedule, "every:") {
+		d, err := time.ParseDuration(strings.TrimPrefix(schedule, "every:"))
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid every schedule: %w", err)
+		}
+		if d <= 0 {
+			return time.Time{}, fmt.Errorf("every duration must be positive")
+		}
+		return after.Add(d), nil
+	}
+
+	// Cron expression
+	sched, err := s.cronParser.Parse(schedule)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid cron expression: %w", err)
+	}
+	return sched.Next(after), nil
+}
+
+// ComputeNextRun is exported for testing.
+func (s *CronScheduler) ComputeNextRun(schedule string, after time.Time) (time.Time, error) {
+	return s.computeNextRun(schedule, after)
+}

--- a/messaging/cron_commands.go
+++ b/messaging/cron_commands.go
@@ -1,0 +1,186 @@
+package messaging
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const cronUsage = `Usage:
+  /cron list
+  /cron add "<name>" <schedule> "<message>"
+  /cron delete <id>
+  /cron enable <id>
+  /cron disable <id>
+
+Schedule formats:
+  every:5m                    — run every 5 minutes
+  every:24h                   — run every 24 hours
+  at:2026-04-01T09:00:00      — one-shot at specific time
+  */30 * * * *                — cron expression (every 30 min)
+  0 9 * * 1-5                 — cron expression (weekdays 9am)`
+
+// HandleCronCommand processes /cron subcommands.
+func HandleCronCommand(store *CronStore, text string) string {
+	parts := strings.Fields(text)
+	if len(parts) < 2 {
+		return cronUsage
+	}
+	sub := strings.ToLower(parts[1])
+
+	switch sub {
+	case "list":
+		return cronList(store)
+	case "add":
+		return cronAdd(store, text)
+	case "delete", "del", "rm":
+		if len(parts) < 3 {
+			return "Usage: /cron delete <id>"
+		}
+		return cronDelete(store, parts[2])
+	case "enable":
+		if len(parts) < 3 {
+			return "Usage: /cron enable <id>"
+		}
+		return cronSetEnabled(store, parts[2], true)
+	case "disable":
+		if len(parts) < 3 {
+			return "Usage: /cron disable <id>"
+		}
+		return cronSetEnabled(store, parts[2], false)
+	default:
+		return cronUsage
+	}
+}
+
+func cronList(store *CronStore) string {
+	jobs := store.List()
+	if len(jobs) == 0 {
+		return "No cron jobs configured."
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Cron Jobs (%d)\n\n", len(jobs)))
+	for _, j := range jobs {
+		status := "enabled"
+		if !j.Enabled {
+			status = "disabled"
+		}
+		next := "—"
+		if !j.State.NextRunAt.IsZero() && j.Enabled {
+			next = j.State.NextRunAt.Format("01/02 15:04")
+		}
+		lastRun := "never"
+		if !j.State.LastRunAt.IsZero() {
+			lastRun = j.State.LastRunAt.Format("01/02 15:04")
+		}
+		sb.WriteString(fmt.Sprintf("[%s] %s (%s)\n", j.ID, j.Name, status))
+		sb.WriteString(fmt.Sprintf("  Schedule: %s\n", j.Schedule))
+		sb.WriteString(fmt.Sprintf("  Message: %s\n", truncateStr(j.Message, 60)))
+		sb.WriteString(fmt.Sprintf("  Next: %s | Last: %s | Runs: %d\n\n", next, lastRun, j.State.RunCount))
+	}
+	return sb.String()
+}
+
+// cronAdd parses: /cron add "name" schedule "message"
+func cronAdd(store *CronStore, text string) string {
+	name, schedule, message, err := parseCronAddArgs(text)
+	if err != nil {
+		return fmt.Sprintf("Error: %v\n\n%s", err, cronUsage)
+	}
+
+	job := CronJob{
+		Name:     name,
+		Enabled:  true,
+		Schedule: schedule,
+		Message:  message,
+	}
+
+	if strings.HasPrefix(schedule, "at:") {
+		job.State.DeleteAfter = true
+	}
+
+	parser := NewCronScheduler(nil, nil, "", nil)
+	next, err := parser.ComputeNextRun(schedule, time.Now())
+	if err != nil {
+		return fmt.Sprintf("Invalid schedule %q: %v", schedule, err)
+	}
+	job.State.NextRunAt = next
+
+	if err := store.Add(job); err != nil {
+		return fmt.Sprintf("Failed to add job: %v", err)
+	}
+	return fmt.Sprintf("Job %s added (next run: %s)", name, next.Format("01/02 15:04"))
+}
+
+func cronDelete(store *CronStore, id string) string {
+	if err := store.Delete(id); err != nil {
+		return fmt.Sprintf("Error: %v", err)
+	}
+	return fmt.Sprintf("Job %s deleted.", id)
+}
+
+func cronSetEnabled(store *CronStore, id string, enabled bool) string {
+	if err := store.SetEnabled(id, enabled); err != nil {
+		return fmt.Sprintf("Error: %v", err)
+	}
+	action := "enabled"
+	if !enabled {
+		action = "disabled"
+	}
+	return fmt.Sprintf("Job %s %s.", id, action)
+}
+
+// parseCronAddArgs parses: /cron add "name" schedule "message"
+func parseCronAddArgs(text string) (name, schedule, message string, err error) {
+	after := strings.TrimSpace(text[len("/cron add"):])
+
+	name, after, err = extractQuoted(after)
+	if err != nil {
+		return "", "", "", fmt.Errorf("name must be quoted: %w", err)
+	}
+
+	after = strings.TrimSpace(after)
+	if after == "" {
+		return "", "", "", fmt.Errorf("missing schedule and message")
+	}
+
+	lastQuote := strings.LastIndex(after, `"`)
+	if lastQuote <= 0 {
+		return "", "", "", fmt.Errorf("message must be quoted")
+	}
+	secondLastQuote := strings.LastIndex(after[:lastQuote], `"`)
+	if secondLastQuote < 0 {
+		return "", "", "", fmt.Errorf("message must be quoted")
+	}
+
+	schedule = strings.TrimSpace(after[:secondLastQuote])
+	message = after[secondLastQuote+1 : lastQuote]
+
+	if schedule == "" {
+		return "", "", "", fmt.Errorf("missing schedule")
+	}
+	if message == "" {
+		return "", "", "", fmt.Errorf("missing message")
+	}
+
+	return name, schedule, message, nil
+}
+
+func extractQuoted(s string) (quoted, rest string, err error) {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 || s[0] != '"' {
+		return "", "", fmt.Errorf("expected opening quote")
+	}
+	end := strings.Index(s[1:], `"`)
+	if end < 0 {
+		return "", "", fmt.Errorf("missing closing quote")
+	}
+	return s[1 : end+1], s[end+2:], nil
+}
+
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/messaging/cron_commands.go
+++ b/messaging/cron_commands.go
@@ -21,7 +21,8 @@ Schedule formats:
   0 9 * * 1-5                 — cron expression (weekdays 9am)`
 
 // HandleCronCommand processes /cron subcommands.
-func HandleCronCommand(store *CronStore, text string) string {
+// userID is recorded on newly created jobs so results go back to the originating user.
+func HandleCronCommand(store *CronStore, text, userID string) string {
 	parts := strings.Fields(text)
 	if len(parts) < 2 {
 		return cronUsage
@@ -32,7 +33,7 @@ func HandleCronCommand(store *CronStore, text string) string {
 	case "list":
 		return cronList(store)
 	case "add":
-		return cronAdd(store, text)
+		return cronAdd(store, text, userID)
 	case "delete", "del", "rm":
 		if len(parts) < 3 {
 			return "Usage: /cron delete <id>"
@@ -82,7 +83,7 @@ func cronList(store *CronStore) string {
 }
 
 // cronAdd parses: /cron add "name" schedule "message"
-func cronAdd(store *CronStore, text string) string {
+func cronAdd(store *CronStore, text, userID string) string {
 	name, schedule, message, err := parseCronAddArgs(text)
 	if err != nil {
 		return fmt.Sprintf("Error: %v\n\n%s", err, cronUsage)
@@ -93,6 +94,7 @@ func cronAdd(store *CronStore, text string) string {
 		Enabled:  true,
 		Schedule: schedule,
 		Message:  message,
+		UserID:   userID,
 	}
 
 	if strings.HasPrefix(schedule, "at:") {

--- a/messaging/cron_store.go
+++ b/messaging/cron_store.go
@@ -1,0 +1,179 @@
+package messaging
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CronJob represents a scheduled job.
+type CronJob struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Enabled  bool     `json:"enabled"`
+	Schedule string   `json:"schedule"` // cron expr "*/30 * * * *", interval "every:5m", or one-shot "at:2026-04-01T09:00:00"
+	Message  string   `json:"message"`
+	UserID   string   `json:"user_id,omitempty"` // target user (default: first account owner)
+	Agent    string   `json:"agent,omitempty"`    // target agent (default: default agent)
+	State    JobState `json:"state"`
+}
+
+// JobState holds runtime state for a job.
+type JobState struct {
+	NextRunAt   time.Time `json:"next_run_at"`
+	LastRunAt   time.Time `json:"last_run_at,omitempty"`
+	LastStatus  string    `json:"last_status,omitempty"` // "ok", "error", "skipped"
+	LastError   string    `json:"last_error,omitempty"`
+	RunCount    int       `json:"run_count"`
+	ErrorCount  int       `json:"error_count"`
+	DeleteAfter bool      `json:"delete_after,omitempty"` // auto-delete after one-shot runs
+}
+
+type cronStoreFile struct {
+	Version int       `json:"version"`
+	Jobs    []CronJob `json:"jobs"`
+}
+
+// CronStore manages persistent cron job storage.
+type CronStore struct {
+	mu   sync.Mutex
+	path string
+	jobs []CronJob
+}
+
+// NewCronStore creates a store backed by a JSON file.
+func NewCronStore(path string) *CronStore {
+	return &CronStore{path: path}
+}
+
+// DefaultCronStorePath returns the default cron store path.
+func DefaultCronStorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".weclaw", "cron", "jobs.json"), nil
+}
+
+// Load reads jobs from disk.
+func (s *CronStore) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.jobs = nil
+			return nil
+		}
+		return fmt.Errorf("read cron store: %w", err)
+	}
+
+	var file cronStoreFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return fmt.Errorf("parse cron store: %w", err)
+	}
+	s.jobs = file.Jobs
+	return nil
+}
+
+// Save writes jobs to disk.
+func (s *CronStore) Save() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveLocked()
+}
+
+func (s *CronStore) saveLocked() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create cron dir: %w", err)
+	}
+
+	file := cronStoreFile{Version: 1, Jobs: s.jobs}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cron store: %w", err)
+	}
+	return os.WriteFile(s.path, data, 0o600)
+}
+
+// List returns all jobs.
+func (s *CronStore) List() []CronJob {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]CronJob, len(s.jobs))
+	copy(out, s.jobs)
+	return out
+}
+
+// Add adds a new job and persists.
+func (s *CronStore) Add(job CronJob) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if job.ID == "" {
+		job.ID = uuid.New().String()[:8]
+	}
+	s.jobs = append(s.jobs, job)
+	return s.saveLocked()
+}
+
+// Delete removes a job by ID and persists.
+func (s *CronStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, j := range s.jobs {
+		if j.ID == id {
+			s.jobs = append(s.jobs[:i], s.jobs[i+1:]...)
+			return s.saveLocked()
+		}
+	}
+	return fmt.Errorf("job %q not found", id)
+}
+
+// SetEnabled enables or disables a job by ID.
+func (s *CronStore) SetEnabled(id string, enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			s.jobs[i].Enabled = enabled
+			return s.saveLocked()
+		}
+	}
+	return fmt.Errorf("job %q not found", id)
+}
+
+// UpdateState updates the runtime state for a job.
+func (s *CronStore) UpdateState(id string, state JobState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range s.jobs {
+		if s.jobs[i].ID == id {
+			s.jobs[i].State = state
+			_ = s.saveLocked()
+			return
+		}
+	}
+}
+
+// Get returns a job by ID.
+func (s *CronStore) Get(id string) (CronJob, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, j := range s.jobs {
+		if j.ID == id {
+			return j, true
+		}
+	}
+	return CronJob{}, false
+}

--- a/messaging/cron_test.go
+++ b/messaging/cron_test.go
@@ -1,0 +1,306 @@
+package messaging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCronStore_AddListDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jobs.json")
+	store := NewCronStore(path)
+
+	if err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.List()) != 0 {
+		t.Fatal("expected empty store")
+	}
+
+	job := CronJob{Name: "test", Enabled: true, Schedule: "every:5m", Message: "hello"}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	jobs := store.List()
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Name != "test" {
+		t.Fatalf("expected name 'test', got %q", jobs[0].Name)
+	}
+	if jobs[0].ID == "" {
+		t.Fatal("expected auto-generated ID")
+	}
+
+	// Verify persistence
+	store2 := NewCronStore(path)
+	if err := store2.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if len(store2.List()) != 1 {
+		t.Fatal("expected 1 job after reload")
+	}
+
+	// Delete
+	if err := store.Delete(jobs[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.List()) != 0 {
+		t.Fatal("expected 0 jobs after delete")
+	}
+}
+
+func TestCronStore_EnableDisable(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	job := CronJob{Name: "toggle", Enabled: true, Schedule: "every:1h", Message: "test"}
+	_ = store.Add(job)
+	id := store.List()[0].ID
+
+	_ = store.SetEnabled(id, false)
+	j, ok := store.Get(id)
+	if !ok {
+		t.Fatal("job not found")
+	}
+	if j.Enabled {
+		t.Fatal("expected disabled")
+	}
+
+	_ = store.SetEnabled(id, true)
+	j, _ = store.Get(id)
+	if !j.Enabled {
+		t.Fatal("expected enabled")
+	}
+}
+
+func TestCronStore_DeleteNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	if err := store.Delete("nonexistent"); err == nil {
+		t.Fatal("expected error for nonexistent ID")
+	}
+}
+
+func TestCronStore_FileNotExist(t *testing.T) {
+	store := NewCronStore("/tmp/weclaw-test-nonexistent/jobs.json")
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load should succeed for missing file, got: %v", err)
+	}
+	if len(store.List()) != 0 {
+		t.Fatal("expected empty list")
+	}
+}
+
+func TestComputeNextRun_Every(t *testing.T) {
+	s := NewCronScheduler(nil, nil, "", nil)
+	now := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+
+	next, err := s.ComputeNextRun("every:5m", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := now.Add(5 * time.Minute)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestComputeNextRun_At(t *testing.T) {
+	s := NewCronScheduler(nil, nil, "", nil)
+	now := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+
+	next, err := s.ComputeNextRun("at:2026-04-01T10:00:00Z", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+
+	// Past time should error
+	_, err = s.ComputeNextRun("at:2020-01-01T00:00:00Z", now)
+	if err == nil {
+		t.Fatal("expected error for past time")
+	}
+}
+
+func TestComputeNextRun_CronExpr(t *testing.T) {
+	s := NewCronScheduler(nil, nil, "", nil)
+	now := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+
+	next, err := s.ComputeNextRun("*/30 * * * *", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := time.Date(2026, 4, 1, 9, 30, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestComputeNextRun_Invalid(t *testing.T) {
+	s := NewCronScheduler(nil, nil, "", nil)
+	now := time.Now()
+
+	tests := []string{"bad", "every:-1m", "at:not-a-date", "every:0s"}
+	for _, sched := range tests {
+		_, err := s.ComputeNextRun(sched, now)
+		if err == nil {
+			t.Errorf("expected error for schedule %q", sched)
+		}
+	}
+}
+
+func TestParseCronAddArgs(t *testing.T) {
+	tests := []struct {
+		input   string
+		name    string
+		sched   string
+		msg     string
+		wantErr bool
+	}{
+		{
+			input: `/cron add "standup" every:24h "summarize yesterday"`,
+			name:  "standup", sched: "every:24h", msg: "summarize yesterday",
+		},
+		{
+			input: `/cron add "check" */30 * * * * "check emails"`,
+			name:  "check", sched: "*/30 * * * *", msg: "check emails",
+		},
+		{
+			input:   `/cron add missing quotes`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		name, sched, msg, err := parseCronAddArgs(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseCronAddArgs(%q): expected error", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseCronAddArgs(%q): %v", tt.input, err)
+			continue
+		}
+		if name != tt.name || sched != tt.sched || msg != tt.msg {
+			t.Errorf("parseCronAddArgs(%q) = (%q,%q,%q), want (%q,%q,%q)", tt.input, name, sched, msg, tt.name, tt.sched, tt.msg)
+		}
+	}
+}
+
+func TestHandleCronCommand_List_Empty(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	reply := HandleCronCommand(store, "/cron list")
+	if reply != "No cron jobs configured." {
+		t.Fatalf("unexpected reply: %q", reply)
+	}
+}
+
+func TestHandleCronCommand_AddAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	reply := HandleCronCommand(store, `/cron add "test" every:1h "hello world"`)
+	if !strings.Contains(reply, "added") {
+		t.Fatalf("expected 'added' in reply: %q", reply)
+	}
+
+	reply = HandleCronCommand(store, "/cron list")
+	if !strings.Contains(reply, "test") {
+		t.Fatalf("expected 'test' in list: %q", reply)
+	}
+}
+
+func TestHandleCronCommand_DeleteEnableDisable(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	HandleCronCommand(store, `/cron add "test" every:1h "hello"`)
+	id := store.List()[0].ID
+
+	reply := HandleCronCommand(store, "/cron disable "+id)
+	if !strings.Contains(reply, "disabled") {
+		t.Fatalf("unexpected: %q", reply)
+	}
+
+	reply = HandleCronCommand(store, "/cron enable "+id)
+	if !strings.Contains(reply, "enabled") {
+		t.Fatalf("unexpected: %q", reply)
+	}
+
+	reply = HandleCronCommand(store, "/cron delete "+id)
+	if !strings.Contains(reply, "deleted") {
+		t.Fatalf("unexpected: %q", reply)
+	}
+}
+
+func TestHandleCronCommand_Usage(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	reply := HandleCronCommand(store, "/cron")
+	if !strings.Contains(reply, "Usage") {
+		t.Fatalf("expected usage: %q", reply)
+	}
+}
+
+func TestCronStore_FileFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jobs.json")
+	store := NewCronStore(path)
+	_ = store.Load()
+
+	_ = store.Add(CronJob{Name: "a", Enabled: true, Schedule: "every:1h", Message: "test"})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"version": 1`) {
+		t.Fatalf("file should contain version: %s", string(data))
+	}
+}
+
+func TestCronStore_UpdateState(t *testing.T) {
+	dir := t.TempDir()
+	store := NewCronStore(filepath.Join(dir, "jobs.json"))
+	_ = store.Load()
+
+	_ = store.Add(CronJob{Name: "stateful", Enabled: true, Schedule: "every:1h", Message: "test"})
+	id := store.List()[0].ID
+
+	now := time.Now()
+	store.UpdateState(id, JobState{
+		LastRunAt:  now,
+		LastStatus: "ok",
+		RunCount:   1,
+	})
+
+	j, ok := store.Get(id)
+	if !ok {
+		t.Fatal("job not found")
+	}
+	if j.State.RunCount != 1 {
+		t.Fatalf("expected RunCount=1, got %d", j.State.RunCount)
+	}
+	if j.State.LastStatus != "ok" {
+		t.Fatalf("expected LastStatus=ok, got %q", j.State.LastStatus)
+	}
+}

--- a/messaging/cron_test.go
+++ b/messaging/cron_test.go
@@ -204,7 +204,7 @@ func TestHandleCronCommand_List_Empty(t *testing.T) {
 	store := NewCronStore(filepath.Join(dir, "jobs.json"))
 	_ = store.Load()
 
-	reply := HandleCronCommand(store, "/cron list")
+	reply := HandleCronCommand(store, "/cron list", "user1")
 	if reply != "No cron jobs configured." {
 		t.Fatalf("unexpected reply: %q", reply)
 	}
@@ -215,12 +215,18 @@ func TestHandleCronCommand_AddAndList(t *testing.T) {
 	store := NewCronStore(filepath.Join(dir, "jobs.json"))
 	_ = store.Load()
 
-	reply := HandleCronCommand(store, `/cron add "test" every:1h "hello world"`)
+	reply := HandleCronCommand(store, `/cron add "test" every:1h "hello world"`, "user1")
 	if !strings.Contains(reply, "added") {
 		t.Fatalf("expected 'added' in reply: %q", reply)
 	}
 
-	reply = HandleCronCommand(store, "/cron list")
+	// Verify userID was recorded on the job
+	jobs := store.List()
+	if len(jobs) != 1 || jobs[0].UserID != "user1" {
+		t.Fatalf("expected UserID 'user1', got %q", jobs[0].UserID)
+	}
+
+	reply = HandleCronCommand(store, "/cron list", "user1")
 	if !strings.Contains(reply, "test") {
 		t.Fatalf("expected 'test' in list: %q", reply)
 	}
@@ -231,20 +237,20 @@ func TestHandleCronCommand_DeleteEnableDisable(t *testing.T) {
 	store := NewCronStore(filepath.Join(dir, "jobs.json"))
 	_ = store.Load()
 
-	HandleCronCommand(store, `/cron add "test" every:1h "hello"`)
+	HandleCronCommand(store, `/cron add "test" every:1h "hello"`, "user1")
 	id := store.List()[0].ID
 
-	reply := HandleCronCommand(store, "/cron disable "+id)
+	reply := HandleCronCommand(store, "/cron disable "+id, "user1")
 	if !strings.Contains(reply, "disabled") {
 		t.Fatalf("unexpected: %q", reply)
 	}
 
-	reply = HandleCronCommand(store, "/cron enable "+id)
+	reply = HandleCronCommand(store, "/cron enable "+id, "user1")
 	if !strings.Contains(reply, "enabled") {
 		t.Fatalf("unexpected: %q", reply)
 	}
 
-	reply = HandleCronCommand(store, "/cron delete "+id)
+	reply = HandleCronCommand(store, "/cron delete "+id, "user1")
 	if !strings.Contains(reply, "deleted") {
 		t.Fatalf("unexpected: %q", reply)
 	}
@@ -255,7 +261,7 @@ func TestHandleCronCommand_Usage(t *testing.T) {
 	store := NewCronStore(filepath.Join(dir, "jobs.json"))
 	_ = store.Load()
 
-	reply := HandleCronCommand(store, "/cron")
+	reply := HandleCronCommand(store, "/cron", "user1")
 	if !strings.Contains(reply, "Usage") {
 		t.Fatalf("expected usage: %q", reply)
 	}

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -42,6 +42,7 @@ type Handler struct {
 	contextTokens sync.Map   // map[userID]contextToken
 	saveDir       string     // directory to save images/files to
 	seenMsgs      sync.Map   // map[int64]time.Time — dedup by message_id
+	cronStore     *CronStore // cron job store (nil if not configured)
 }
 
 // NewHandler creates a new message handler.
@@ -57,6 +58,11 @@ func NewHandler(factory AgentFactory, saveDefault SaveDefaultFunc) *Handler {
 // SetSaveDir sets the directory for saving images and files.
 func (h *Handler) SetSaveDir(dir string) {
 	h.saveDir = dir
+}
+
+// SetCronStore sets the cron job store for /cron commands.
+func (h *Handler) SetCronStore(store *CronStore) {
+	h.cronStore = store
 }
 
 // cleanSeenMsgs removes entries older than 5 minutes from the dedup cache.
@@ -146,6 +152,16 @@ func (h *Handler) getDefaultAgent() agent.Agent {
 		return nil
 	}
 	return h.agents[h.defaultName]
+}
+
+// GetDefaultAgent returns the default agent (exported for cron/heartbeat).
+func (h *Handler) GetDefaultAgent() agent.Agent {
+	return h.getDefaultAgent()
+}
+
+// GetAgent returns a running agent by name (exported for cron).
+func (h *Handler) GetAgent(ctx context.Context, name string) (agent.Agent, error) {
+	return h.getAgent(ctx, name)
 }
 
 // isKnownAgent checks if a name corresponds to a configured agent.
@@ -347,6 +363,16 @@ func (h *Handler) HandleMessage(ctx context.Context, client *ilink.Client, msg i
 		reply := h.handleCwd(trimmed)
 		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
 			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
+		}
+		return
+	} else if strings.HasPrefix(trimmed, "/cron") {
+		if h.cronStore == nil {
+			_ = SendTextReply(ctx, client, msg.FromUserID, "Cron is not configured.", msg.ContextToken, clientID)
+			return
+		}
+		reply := HandleCronCommand(h.cronStore, trimmed)
+		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
+			log.Printf("[handler] failed to send cron reply to %s: %v", msg.FromUserID, err)
 		}
 		return
 	}
@@ -690,6 +716,7 @@ func buildHelpText() string {
 @a @b msg - Broadcast to multiple agents
 /new or /clear - Start a new session
 /cwd /path - Switch workspace directory
+/cron list|add|delete|enable|disable - Manage scheduled tasks
 /info - Show current agent info
 /help - Show this help message
 

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -370,7 +370,7 @@ func (h *Handler) HandleMessage(ctx context.Context, client *ilink.Client, msg i
 			_ = SendTextReply(ctx, client, msg.FromUserID, "Cron is not configured.", msg.ContextToken, clientID)
 			return
 		}
-		reply := HandleCronCommand(h.cronStore, trimmed)
+		reply := HandleCronCommand(h.cronStore, trimmed, msg.FromUserID)
 		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
 			log.Printf("[handler] failed to send cron reply to %s: %v", msg.FromUserID, err)
 		}

--- a/messaging/heartbeat.go
+++ b/messaging/heartbeat.go
@@ -44,6 +44,9 @@ func NewHeartbeatRunner(cfg config.HeartbeatConfig, client *ilink.Client, target
 		if err != nil {
 			return nil, fmt.Errorf("invalid heartbeat interval %q: %w", cfg.Interval, err)
 		}
+		if d <= 0 {
+			return nil, fmt.Errorf("heartbeat interval must be positive, got %v", d)
+		}
 		interval = d
 	}
 

--- a/messaging/heartbeat.go
+++ b/messaging/heartbeat.go
@@ -1,0 +1,225 @@
+package messaging
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fastclaw-ai/weclaw/agent"
+	"github.com/fastclaw-ai/weclaw/config"
+	"github.com/fastclaw-ai/weclaw/ilink"
+)
+
+const (
+	heartbeatOKToken     = "HEARTBEAT_OK"
+	heartbeatDedupWindow = 24 * time.Hour
+	defaultHeartbeatFile = "HEARTBEAT.md"
+)
+
+// HeartbeatRunner periodically reads HEARTBEAT.md and sends it to the default agent.
+type HeartbeatRunner struct {
+	cfg         config.HeartbeatConfig
+	client      *ilink.Client
+	targetUser  string
+	getAgent    func() agent.Agent
+	interval    time.Duration
+	location    *time.Location
+	activeStart int // minutes from midnight
+	activeEnd   int // minutes from midnight
+	mu          sync.Mutex
+	recentHash  map[string]time.Time // hash -> last seen
+}
+
+// NewHeartbeatRunner creates a heartbeat runner.
+func NewHeartbeatRunner(cfg config.HeartbeatConfig, client *ilink.Client, targetUser string, getAgent func() agent.Agent) (*HeartbeatRunner, error) {
+	interval := 30 * time.Minute
+	if cfg.Interval != "" {
+		d, err := time.ParseDuration(cfg.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("invalid heartbeat interval %q: %w", cfg.Interval, err)
+		}
+		interval = d
+	}
+
+	loc := time.Local
+	if cfg.Timezone != "" {
+		l, err := time.LoadLocation(cfg.Timezone)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timezone %q: %w", cfg.Timezone, err)
+		}
+		loc = l
+	}
+
+	r := &HeartbeatRunner{
+		cfg:        cfg,
+		client:     client,
+		targetUser: targetUser,
+		getAgent:   getAgent,
+		interval:   interval,
+		location:   loc,
+		recentHash: make(map[string]time.Time),
+	}
+
+	if cfg.ActiveHours != "" {
+		start, end, err := parseActiveHours(cfg.ActiveHours)
+		if err != nil {
+			return nil, err
+		}
+		r.activeStart = start
+		r.activeEnd = end
+	}
+
+	return r, nil
+}
+
+// Start runs the heartbeat loop until context is cancelled.
+func (r *HeartbeatRunner) Start(ctx context.Context) {
+	log.Printf("[heartbeat] runner started (interval=%s, activeHours=%s)", r.interval, r.cfg.ActiveHours)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[heartbeat] runner stopped")
+			return
+		case <-ticker.C:
+			r.tick(ctx)
+		}
+	}
+}
+
+func (r *HeartbeatRunner) tick(ctx context.Context) {
+	if !r.isActiveTime() {
+		return
+	}
+
+	content, err := r.readHeartbeatFile()
+	if err != nil {
+		return
+	}
+	if isEffectivelyEmpty(content) {
+		return
+	}
+
+	ag := r.getAgent()
+	if ag == nil {
+		return
+	}
+
+	prompt := fmt.Sprintf("This is a scheduled heartbeat check. Follow the instructions below and report anything that needs attention. If everything is fine, reply with exactly: %s\n\n%s", heartbeatOKToken, content)
+	log.Println("[heartbeat] running check")
+
+	reply, err := ag.Chat(ctx, "heartbeat", prompt)
+	if err != nil {
+		log.Printf("[heartbeat] agent error: %v", err)
+		return
+	}
+
+	reply = strings.TrimSpace(reply)
+	if reply == "" || strings.EqualFold(reply, heartbeatOKToken) || strings.HasPrefix(strings.TrimSpace(strings.ToUpper(reply)), heartbeatOKToken) {
+		log.Println("[heartbeat] all clear")
+		return
+	}
+
+	if r.isDuplicate(reply) {
+		log.Println("[heartbeat] duplicate reply suppressed")
+		return
+	}
+
+	if r.client != nil && r.targetUser != "" {
+		if err := SendTextReply(ctx, r.client, r.targetUser, "[Heartbeat] "+reply, "", ""); err != nil {
+			log.Printf("[heartbeat] failed to send reply: %v", err)
+		}
+	}
+}
+
+func (r *HeartbeatRunner) isActiveTime() bool {
+	if r.cfg.ActiveHours == "" {
+		return true
+	}
+	now := time.Now().In(r.location)
+	mins := now.Hour()*60 + now.Minute()
+	if r.activeStart <= r.activeEnd {
+		return mins >= r.activeStart && mins < r.activeEnd
+	}
+	// Wraps midnight (e.g. 22:00-06:00)
+	return mins >= r.activeStart || mins < r.activeEnd
+}
+
+func (r *HeartbeatRunner) readHeartbeatFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(home, ".weclaw", defaultHeartbeatFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (r *HeartbeatRunner) isDuplicate(reply string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	h := fmt.Sprintf("%x", sha256.Sum256([]byte(reply)))
+	if t, ok := r.recentHash[h]; ok && time.Since(t) < heartbeatDedupWindow {
+		return true
+	}
+	r.recentHash[h] = time.Now()
+
+	// Clean old entries
+	cutoff := time.Now().Add(-heartbeatDedupWindow)
+	for k, t := range r.recentHash {
+		if t.Before(cutoff) {
+			delete(r.recentHash, k)
+		}
+	}
+	return false
+}
+
+func isEffectivelyEmpty(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "<!--") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func parseActiveHours(s string) (start, end int, err error) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid active_hours format %q, expected HH:MM-HH:MM", s)
+	}
+	start, err = parseTimeOfDay(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid active_hours start: %w", err)
+	}
+	end, err = parseTimeOfDay(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid active_hours end: %w", err)
+	}
+	return start, end, nil
+}
+
+func parseTimeOfDay(s string) (int, error) {
+	var h, m int
+	if _, err := fmt.Sscanf(s, "%d:%d", &h, &m); err != nil {
+		return 0, fmt.Errorf("invalid time %q, expected HH:MM", s)
+	}
+	if h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, fmt.Errorf("time %q out of range", s)
+	}
+	return h*60 + m, nil
+}

--- a/messaging/heartbeat_test.go
+++ b/messaging/heartbeat_test.go
@@ -1,0 +1,103 @@
+package messaging
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseActiveHours(t *testing.T) {
+	tests := []struct {
+		input string
+		start int
+		end   int
+		err   bool
+	}{
+		{"09:00-18:00", 540, 1080, false},
+		{"00:00-23:59", 0, 1439, false},
+		{"22:00-06:00", 1320, 360, false},
+		{"bad", 0, 0, true},
+		{"25:00-18:00", 0, 0, true},
+		{"09:00-18:60", 0, 0, true},
+	}
+	for _, tt := range tests {
+		start, end, err := parseActiveHours(tt.input)
+		if tt.err {
+			if err == nil {
+				t.Errorf("parseActiveHours(%q): expected error", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseActiveHours(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if start != tt.start || end != tt.end {
+			t.Errorf("parseActiveHours(%q) = (%d,%d), want (%d,%d)", tt.input, start, end, tt.start, tt.end)
+		}
+	}
+}
+
+func TestIsEffectivelyEmpty(t *testing.T) {
+	tests := []struct {
+		content string
+		empty   bool
+	}{
+		{"", true},
+		{"\n\n", true},
+		{"# Title\n\n", true},
+		{"# Title\n<!-- comment -->\n", true},
+		{"check emails", false},
+		{"# Title\n- do stuff\n", false},
+	}
+	for _, tt := range tests {
+		got := isEffectivelyEmpty(tt.content)
+		if got != tt.empty {
+			t.Errorf("isEffectivelyEmpty(%q) = %v, want %v", tt.content, got, tt.empty)
+		}
+	}
+}
+
+func TestHeartbeatRunnerIsDuplicate(t *testing.T) {
+	r := &HeartbeatRunner{recentHash: make(map[string]time.Time)}
+	if r.isDuplicate("hello") {
+		t.Error("first call should not be duplicate")
+	}
+	if !r.isDuplicate("hello") {
+		t.Error("second call should be duplicate")
+	}
+	if r.isDuplicate("different") {
+		t.Error("different content should not be duplicate")
+	}
+}
+
+func TestParseTimeOfDay(t *testing.T) {
+	tests := []struct {
+		input string
+		mins  int
+		err   bool
+	}{
+		{"09:00", 540, false},
+		{"00:00", 0, false},
+		{"23:59", 1439, false},
+		{"12:30", 750, false},
+		{"25:00", 0, true},
+		{"09:60", 0, true},
+		{"bad", 0, true},
+	}
+	for _, tt := range tests {
+		mins, err := parseTimeOfDay(tt.input)
+		if tt.err {
+			if err == nil {
+				t.Errorf("parseTimeOfDay(%q): expected error", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseTimeOfDay(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if mins != tt.mins {
+			t.Errorf("parseTimeOfDay(%q) = %d, want %d", tt.input, mins, tt.mins)
+		}
+	}
+}

--- a/messaging/heartbeat_test.go
+++ b/messaging/heartbeat_test.go
@@ -3,6 +3,8 @@ package messaging
 import (
 	"testing"
 	"time"
+
+	"github.com/fastclaw-ai/weclaw/config"
 )
 
 func TestParseActiveHours(t *testing.T) {
@@ -53,6 +55,28 @@ func TestIsEffectivelyEmpty(t *testing.T) {
 		got := isEffectivelyEmpty(tt.content)
 		if got != tt.empty {
 			t.Errorf("isEffectivelyEmpty(%q) = %v, want %v", tt.content, got, tt.empty)
+		}
+	}
+}
+
+func TestNewHeartbeatRunner_RejectsNonPositiveInterval(t *testing.T) {
+	tests := []struct {
+		interval string
+		wantErr  bool
+	}{
+		{"0s", true},
+		{"-1m", true},
+		{"30m", false},
+		{"1h", false},
+	}
+	for _, tt := range tests {
+		cfg := config.HeartbeatConfig{Enabled: true, Interval: tt.interval}
+		_, err := NewHeartbeatRunner(cfg, nil, "", nil)
+		if tt.wantErr && err == nil {
+			t.Errorf("interval %q: expected error", tt.interval)
+		}
+		if !tt.wantErr && err != nil {
+			t.Errorf("interval %q: unexpected error: %v", tt.interval, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add two automation features: **Cron Scheduler** and **Heartbeat Runner**.

### Cron Scheduler

Schedule recurring or one-shot tasks via chat commands:

```
/cron add "standup" every:24h "summarize yesterday's work"
/cron add "check" */30 * * * * "check for new PRs"
/cron add "reminder" at:2026-04-01T09:00:00 "sprint review today"
/cron list / delete / enable / disable
```

- Supports cron expressions, fixed intervals (`every:5m`), and one-shot (`at:...`)
- Jobs persisted to `~/.weclaw/cron/jobs.json`
- Uses `robfig/cron/v3` for expression parsing

### Heartbeat Runner

Periodic agent check-in driven by `~/.weclaw/HEARTBEAT.md`:

- Reads checklist on configurable interval
- Sends to default agent; suppresses `HEARTBEAT_OK` replies
- 24h dedup to avoid noise
- Configurable active hours and timezone

### Config

```json
{
  "heartbeat": {
    "enabled": true,
    "interval": "30m",
    "active_hours": "09:00-18:00",
    "timezone": "Asia/Shanghai",
    "target_user": "wechat_user_id"
  }
}
```

### Changes

- `messaging/cron.go` — CronScheduler with tick loop
- `messaging/cron_store.go` — JSON persistence
- `messaging/cron_commands.go` — `/cron` chat command parser
- `messaging/heartbeat.go` — HeartbeatRunner
- `config/config.go` — HeartbeatConfig type
- `cmd/start.go` — Start scheduler + heartbeat using first account's client
- `messaging/handler.go` — `/cron` routing, exported GetDefaultAgent/GetAgent
- 30+ tests, all passing with `-race`
- Updated both READMEs