### PR TITLE
feat(hub): add Agent Hub — cross-agent context sharing via /save, /hu…

### DIFF
--- a/docs/agent-hub-design.md
+++ b/docs/agent-hub-design.md
@@ -1,0 +1,112 @@
+# Agent Hub Design — 跨 Agent 上下文共享
+
+## Problem
+
+WeClaw supports multiple AI agents (Claude, Codex, Gemini, etc.), each with isolated conversation sessions. Users cannot easily share context between agents for collaborative workflows like:
+- Multi-agent debate
+- Chain-of-thought analysis (Agent A outputs → Agent B reviews)
+- Collaborative content creation
+
+## Solution: Agent Hub
+
+A shared context layer built directly into WeClaw's Go codebase, using the filesystem as a persistent message board.
+
+### Architecture
+
+```
+WeChat ←→ WeClaw (handler.go)
+              │
+              ├── Agent A (isolated session)
+              ├── Agent B (isolated session)  
+              └── Agent Hub (shared context)
+                    │
+                    ├── ~/.weclaw/hub/shared/    # shared context files
+                    ├── ~/.weclaw/hub/templates/  # prompt templates
+                    └── /hub, /save commands
+```
+
+### New Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/hub` | Read all shared files and inject as context | `/hub 基于以上分析，给出你的反驳` |
+| `/hub {filename}` | Read specific file from shared | `/hub round1_claude.md 基于此反驳` |
+| `/save {filename} {message}` | Send message and save reply to shared | `/save round1.md 分析AI未来` |
+| `/hub ls` | List files in shared directory | `/hub ls` |
+| `/hub clear` | Clear all shared files | `/hub clear` |
+| `/hub pipe {target}` | Send to agent, save result, auto-chain | `/hub pipe gemini` |
+
+### Workflow Examples
+
+#### Multi-Agent Debate
+```
+1. /save round1_claude.md 从哲学角度分析AI代理是否会替代人类决策
+   → Claude replies, result saved to shared/round1_claude.md
+   
+2. @gemini /hub round1_claude.md 从技术可行性角度反驳以上观点
+   → Gemini reads round1_claude.md, replies with rebuttal
+   
+3. /save round2_gemini.md @gemini 从技术可行性角度反驳
+   → Gemini's rebuttal saved to shared/round2_gemini.md
+   
+4. @claude /hub round2_gemini.md 作为哲学派，回应技术派的反驳
+   → Claude reads the rebuttal, responds
+   
+5. /hub 综合两方观点，给出最终结论
+   → Default agent sees all shared files, synthesizes
+```
+
+#### Chain Collaboration
+```
+1. /save draft.md 写一个关于量子计算的技术博客大纲
+2. @gemini /hub draft.md 基于大纲扩写完整文章
+3. /save article.md @gemini 基于大纲扩写完整文章
+4. @claude /hub article.md 审查文章质量并优化
+```
+
+### Implementation Plan
+
+#### Phase 1: File-based shared context (current)
+- `~/.weclaw/hub/shared/` — shared context files
+- `~/.weclaw/hub/templates/` — prompt templates
+- New commands in `handler.go`: `/hub`, `/save`
+
+#### Phase 2: Auto-save with context injection
+- Agent replies auto-saved when `/save` is used
+- `/hub` auto-injects shared files as system prompt prefix
+- File naming with timestamp and agent name
+
+#### Phase 3: Chain mode (future)
+- `/hub pipe {agent}` — automatic chain: send → save → next
+- Template system for structured workflows
+- History tracking per collaboration session
+
+### File Format
+
+Shared files use Markdown with YAML frontmatter:
+
+```markdown
+---
+agent: claude
+timestamp: 2026-04-02T01:30:00+08:00
+session: debate-001
+round: 1
+---
+
+# Claude's Analysis
+
+[content here]
+```
+
+### Integration Points in weclaw
+
+1. **`messaging/handler.go`** — Add command parsing for `/hub` and `/save`
+2. **`hub/hub.go`** (new package) — Hub logic: read/write shared files, inject context
+3. **`cmd/start.go`** — Initialize Hub with default directory
+
+### Key Design Decisions
+
+1. **Filesystem over database** — Simple, inspectable, no extra dependencies
+2. **Markdown with frontmatter** — Human-readable, agent-friendly, extensible
+3. **Opt-in via commands** — No automatic cross-contamination of agent sessions
+4. **Go-native** — No Python dependencies, fits weclaw's architecture

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -1,0 +1,366 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Hub manages shared context files for cross-agent collaboration.
+type Hub struct {
+	mu        sync.RWMutex
+	sharedDir string // directory for shared context files
+}
+
+// New creates a new Hub with the given shared directory.
+func New(sharedDir string) *Hub {
+	os.MkdirAll(sharedDir, 0o755)
+	return &Hub{sharedDir: sharedDir}
+}
+
+// DefaultDir returns the default hub shared directory path.
+func DefaultDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "weclaw-hub", "shared")
+	}
+	return filepath.Join(home, ".weclaw", "hub", "shared")
+}
+
+// SharedDir returns the hub's shared directory path.
+func (h *Hub) SharedDir() string {
+	return h.sharedDir
+}
+
+// Save writes content to a file in the shared directory with YAML frontmatter.
+// agentName identifies which agent produced the content.
+func (h *Hub) Save(filename, content, agentName string) (string, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Sanitize filename
+	filename = sanitizeFilename(filename)
+	if !strings.HasSuffix(filename, ".md") {
+		filename += ".md"
+	}
+
+	filePath := filepath.Join(h.sharedDir, filename)
+
+	// Validate path is within shared directory (defense in depth)
+	if err := h.validatePath(filePath); err != nil {
+		return "", fmt.Errorf("invalid filename: %w", err)
+	}
+
+	// Build frontmatter
+	timestamp := time.Now().Format("2006-01-02T15:04:05+08:00")
+	frontmatter := fmt.Sprintf("---\nagent: %s\ntimestamp: %s\n---\n\n", agentName, timestamp)
+
+	fullContent := frontmatter + content
+
+	if err := os.WriteFile(filePath, []byte(fullContent), 0o644); err != nil {
+		return "", fmt.Errorf("save hub file: %w", err)
+	}
+
+	return filePath, nil
+}
+
+// SaveRaw writes raw content to a file (no frontmatter) in the shared directory.
+func (h *Hub) SaveRaw(filename, content string) (string, error) {
+	filename = sanitizeFilename(filename)
+	filePath := filepath.Join(h.sharedDir, filename)
+
+	// Validate path is within shared directory (defense in depth)
+	if err := h.validatePath(filePath); err != nil {
+		return "", fmt.Errorf("invalid filename: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("save hub file: %w", err)
+	}
+
+	return filePath, nil
+}
+
+// ReadFile reads a specific file from the shared directory.
+func (h *Hub) ReadFile(filename string) (string, error) {
+	filename = sanitizeFilename(filename)
+	filePath := filepath.Join(h.sharedDir, filename)
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("read hub file: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// ReadAll reads all files from the shared directory and returns their combined content.
+// Returns a formatted context string ready for injection into agent prompts.
+func (h *Hub) ReadAll() (string, error) {
+	entries, err := os.ReadDir(h.sharedDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil // empty hub is fine
+		}
+		return "", fmt.Errorf("read hub directory: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	// Sort by modification time (oldest first)
+	type fileEntry struct {
+		name string
+		info os.FileInfo
+	}
+	var files []fileEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, fileEntry{name: e.Name(), info: info})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].info.ModTime().Before(files[j].info.ModTime())
+	})
+
+	var sb strings.Builder
+	sb.WriteString("=== Agent Hub Shared Context ===\n\n")
+
+	for _, f := range files {
+		data, err := os.ReadFile(filepath.Join(h.sharedDir, f.name))
+		if err != nil {
+			continue
+		}
+
+		sb.WriteString(fmt.Sprintf("--- %s ---\n", f.name))
+		sb.Write(data)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("=== End Hub Context ===\n")
+	return sb.String(), nil
+}
+
+// List returns all filenames in the shared directory.
+func (h *Hub) List() ([]string, error) {
+	entries, err := os.ReadDir(h.sharedDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list hub directory: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+
+	sort.Strings(names)
+	return names, nil
+}
+
+// Clear removes all files from the shared directory.
+func (h *Hub) Clear() (int, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	entries, err := os.ReadDir(h.sharedDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("clear hub directory: %w", err)
+	}
+
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(h.sharedDir, e.Name())
+		if err := os.Remove(path); err != nil {
+			continue
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+// ReadSpecific reads specific files from the shared directory.
+// filenames is a list of filenames to read.
+func (h *Hub) ReadSpecific(filenames []string) (string, error) {
+	var sb strings.Builder
+	sb.WriteString("=== Agent Hub Shared Context ===\n\n")
+
+	for _, fname := range filenames {
+		fname = sanitizeFilename(fname)
+		data, err := os.ReadFile(filepath.Join(h.sharedDir, fname))
+		if err != nil {
+			sb.WriteString(fmt.Sprintf("--- %s (not found) ---\n\n", fname))
+			continue
+		}
+
+		sb.WriteString(fmt.Sprintf("--- %s ---\n", fname))
+		sb.Write(data)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("=== End Hub Context ===\n")
+	return sb.String(), nil
+}
+
+// Exists checks if a file exists in the shared directory.
+func (h *Hub) Exists(filename string) bool {
+	filename = sanitizeFilename(filename)
+	_, err := os.Stat(filepath.Join(h.sharedDir, filename))
+	return err == nil
+}
+
+// FileInfo holds metadata about a hub file.
+type FileInfo struct {
+	Name    string
+	ModTime time.Time
+	Size    int64
+}
+
+// ListWithInfo returns all hub files sorted by modification time (newest first),
+// with metadata including name, modification time, and size.
+func (h *Hub) ListWithInfo() ([]FileInfo, error) {
+	entries, err := os.ReadDir(h.sharedDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list hub directory: %w", err)
+	}
+
+	var files []FileInfo
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, FileInfo{
+			Name:    e.Name(),
+			ModTime: info.ModTime(),
+			Size:    info.Size(),
+		})
+	}
+
+	// Sort by modification time, newest first
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].ModTime.After(files[j].ModTime)
+	})
+
+	return files, nil
+}
+
+// FindByPartialName finds a hub file by partial filename match (case-insensitive).
+// Returns the exact filename if exactly one match is found, or an error if zero or multiple matches.
+func (h *Hub) FindByPartialName(partial string) (string, error) {
+	partial = strings.ToLower(strings.TrimSpace(partial))
+	if partial == "" {
+		return "", fmt.Errorf("empty search term")
+	}
+
+	files, err := h.List()
+	if err != nil {
+		return "", err
+	}
+
+	var matches []string
+	for _, f := range files {
+		if strings.Contains(strings.ToLower(f), partial) {
+			matches = append(matches, f)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no file matching %q", partial)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("ambiguous match %q: found %v", partial, matches)
+	}
+}
+
+// BuildPrompt creates a prompt with hub context injected.
+// If context is empty, returns the original message.
+func BuildPrompt(context, message string) string {
+	if context == "" {
+		return message
+	}
+	return fmt.Sprintf("%s\n\n%s", context, message)
+}
+
+// sanitizeFilename removes path traversal attempts and dangerous characters.
+// It ensures the returned filename is safe to use within the shared directory.
+func sanitizeFilename(name string) string {
+	// Remove null bytes
+	name = strings.ReplaceAll(name, "\x00", "")
+	name = strings.TrimSpace(name)
+
+	// Reject empty, current dir, parent dir references
+	if name == "" || name == "." || name == ".." {
+		return "untitled.md"
+	}
+
+	// Reject any path containing path separators or parent dir references
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") ||
+		strings.Contains(name, "..") {
+		// Extract just the base name as fallback
+		name = filepath.Base(name)
+		// Double-check after Base extraction
+		if name == "" || name == "." || name == ".." {
+			return "untitled.md"
+		}
+	}
+
+	return name
+}
+
+// validatePath ensures the given path is within the hub's shared directory.
+// Returns an error if the path attempts to escape the shared directory.
+func (h *Hub) validatePath(filePath string) error {
+	// Get absolute paths for comparison
+	absSharedDir, err := filepath.Abs(h.sharedDir)
+	if err != nil {
+		return fmt.Errorf("cannot resolve shared directory: %w", err)
+	}
+
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("cannot resolve file path: %w", err)
+	}
+
+	// Clean paths to resolve any .. or .
+	absSharedDir = filepath.Clean(absSharedDir)
+	absFilePath = filepath.Clean(absFilePath)
+
+	// Ensure file path starts with shared directory path
+	if !strings.HasPrefix(absFilePath, absSharedDir+string(filepath.Separator)) &&
+		absFilePath != absSharedDir {
+		return fmt.Errorf("path escapes shared directory: %s", filePath)
+	}
+
+	return nil
+}

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -1,0 +1,283 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHubSaveAndRead(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	// Save a file
+	path, err := h.Save("round1_claude.md", "Hello from Claude", "claude")
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, "round1_claude.md")
+	if path != expectedPath {
+		t.Errorf("expected path %q, got %q", expectedPath, path)
+	}
+
+	// Read it back
+	content, err := h.ReadFile("round1_claude.md")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	if content == "" {
+		t.Error("expected non-empty content")
+	}
+
+	// Check frontmatter
+	if !contains(content, "agent: claude") {
+		t.Error("expected frontmatter with agent: claude")
+	}
+
+	// Check body
+	if !contains(content, "Hello from Claude") {
+		t.Error("expected body content")
+	}
+}
+
+func TestHubReadAll(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	// Save multiple files
+	_, _ = h.Save("round1.md", "First round content", "claude")
+	_, _ = h.Save("round2.md", "Second round content", "gemini")
+
+	// Read all
+	ctx, err := h.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if !contains(ctx, "round1.md") || !contains(ctx, "round2.md") {
+		t.Error("expected both files in context")
+	}
+
+	if !contains(ctx, "Agent Hub Shared Context") {
+		t.Error("expected hub header")
+	}
+}
+
+func TestHubReadAllEmpty(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	ctx, err := h.ReadAll()
+	if err != nil {
+		t.Fatalf("ReadAll on empty dir failed: %v", err)
+	}
+	if ctx != "" {
+		t.Errorf("expected empty context, got %q", ctx)
+	}
+}
+
+func TestHubList(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	_, _ = h.Save("a.md", "content a", "claude")
+	_, _ = h.Save("b.md", "content b", "gemini")
+
+	files, err := h.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestHubClear(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	_, _ = h.Save("a.md", "content a", "claude")
+	_, _ = h.Save("b.md", "content b", "gemini")
+
+	count, err := h.Clear()
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected to clear 2 files, got %d", count)
+	}
+
+	files, _ := h.List()
+	if len(files) != 0 {
+		t.Errorf("expected 0 files after clear, got %d", len(files))
+	}
+}
+
+func TestHubReadSpecific(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	_, _ = h.Save("round1.md", "Round 1 content", "claude")
+	_, _ = h.Save("round2.md", "Round 2 content", "gemini")
+
+	ctx, err := h.ReadSpecific([]string{"round1.md"})
+	if err != nil {
+		t.Fatalf("ReadSpecific failed: %v", err)
+	}
+
+	if !contains(ctx, "Round 1 content") {
+		t.Error("expected round1 content")
+	}
+	if contains(ctx, "Round 2 content") {
+		t.Error("should not contain round2 content")
+	}
+}
+
+func TestHubExists(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	_, _ = h.Save("exists.md", "content", "claude")
+
+	if !h.Exists("exists.md") {
+		t.Error("expected file to exist")
+	}
+	if h.Exists("nope.md") {
+		t.Error("expected file to not exist")
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	// With context
+	result := BuildPrompt("some context", "my message")
+	if result != "some context\n\nmy message" {
+		t.Errorf("unexpected prompt: %q", result)
+	}
+
+	// Without context
+	result = BuildPrompt("", "my message")
+	if result != "my message" {
+		t.Errorf("unexpected prompt without context: %q", result)
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"normal.md", "normal.md"},
+		{"../../../etc/passwd", "passwd"},
+		{"", "untitled.md"},
+		{".", "untitled.md"},
+		{"..", "untitled.md"},
+		{"  spaces  ", "spaces"},
+		{"file/with/slash", "slash"},
+		// Note: backslash is valid in filenames on macOS/Linux, only rejected on Windows
+		{"..hidden", "..hidden"}, // starts with .. but is not exactly .., so it's valid
+	}
+
+	for _, tt := range tests {
+		result := sanitizeFilename(tt.input)
+		if result != tt.expected {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// TestPathTraversalProtection tests that path traversal attacks are blocked
+func TestPathTraversalProtection(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	// Create a file outside the hub directory to test against
+	outsideDir := filepath.Join(dir, "..", "outside")
+	os.MkdirAll(outsideDir, 0755)
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	os.WriteFile(outsideFile, []byte("secret"), 0644)
+
+	// Attempt to save with path traversal - should be sanitized
+	_, err := h.Save("../../../outside/secret.txt", "content", "claude")
+	// Should either save to sanitized path or fail validation
+	if err != nil {
+		// If it errors, it should be a validation error
+		if !contains(err.Error(), "invalid filename") && !contains(err.Error(), "path escapes") {
+			t.Errorf("unexpected error type: %v", err)
+		}
+	}
+
+	// Verify the outside file wasn't modified
+	content, _ := os.ReadFile(outsideFile)
+	if string(content) != "secret" {
+		t.Error("outside file was modified - path traversal protection failed!")
+	}
+}
+
+// TestValidatePath tests the path validation function directly
+func TestValidatePath(t *testing.T) {
+	dir := t.TempDir()
+	h := New(dir)
+
+	// Valid path inside shared directory
+	validPath := filepath.Join(dir, "test.md")
+	if err := h.validatePath(validPath); err != nil {
+		t.Errorf("valid path rejected: %v", err)
+	}
+
+	// Invalid path outside shared directory
+	invalidPath := filepath.Join(dir, "..", "outside", "test.md")
+	if err := h.validatePath(invalidPath); err == nil {
+		t.Error("path traversal should have been rejected")
+	}
+
+	// Path with symlink-like traversal
+	traversalPath := filepath.Join(dir, "subdir", "..", "..", "etc", "passwd")
+	if err := h.validatePath(traversalPath); err == nil {
+		t.Error("traversal path should have been rejected")
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	dir := DefaultDir()
+	if dir == "" {
+		t.Error("expected non-empty default dir")
+	}
+	if !contains(dir, ".weclaw") {
+		t.Errorf("expected .weclaw in path, got %q", dir)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Test that the shared directory is created
+func TestNewCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "subdir", "hub")
+	h := New(dir)
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Error("expected directory to be created")
+	}
+
+	// Hub should be functional
+	path, err := h.Save("test.md", "test", "claude")
+	if err != nil {
+		t.Fatalf("Save to new dir failed: %v", err)
+	}
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+}

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/fastclaw-ai/weclaw/agent"
+	"github.com/fastclaw-ai/weclaw/hub"
 	"github.com/fastclaw-ai/weclaw/ilink"
 	"github.com/google/uuid"
 )
@@ -42,6 +43,8 @@ type Handler struct {
 	contextTokens sync.Map   // map[userID]contextToken
 	saveDir       string     // directory to save images/files to
 	seenMsgs      sync.Map   // map[int64]time.Time — dedup by message_id
+	hub           *hub.Hub   // shared context for cross-agent collaboration
+	lastReplies   sync.Map   // map[userID]string — last agent reply per user (for /save without message)
 }
 
 // NewHandler creates a new message handler.
@@ -51,7 +54,13 @@ func NewHandler(factory AgentFactory, saveDefault SaveDefaultFunc) *Handler {
 		agentWorkDirs: make(map[string]string),
 		factory:       factory,
 		saveDefault:   saveDefault,
+		hub:           hub.New(hub.DefaultDir()),
 	}
+}
+
+// SetHub sets a custom Hub instance (for testing or custom paths).
+func (h *Handler) SetHub(hu *hub.Hub) {
+	h.hub = hu
 }
 
 // SetSaveDir sets the directory for saving images and files.
@@ -199,12 +208,29 @@ func (h *Handler) resolveAlias(name string) string {
 	return name
 }
 
+// isBuiltinCommand returns true if the text starts with a built-in weclaw command.
+// These should NOT be parsed as agent name prefixes.
+func isBuiltinCommand(text string) bool {
+	for _, cmd := range []string{"/help", "/info", "/new", "/clear", "/cwd", "/save", "/hub"} {
+		if text == cmd || strings.HasPrefix(text, cmd+" ") {
+			return true
+		}
+	}
+	return false
+}
+
 // parseCommand checks if text starts with "/" or "@" followed by agent name(s).
 // Supports multiple agents: "@cc @cx hello" returns (["claude","codex"], "hello").
 // Returns (agentNames, actualMessage). Aliases are resolved automatically.
 // If no command prefix, returns (nil, originalText).
+// Built-in commands (/help, /save, /hub, etc.) are NOT parsed as agent names.
 func (h *Handler) parseCommand(text string) ([]string, string) {
 	if !strings.HasPrefix(text, "/") && !strings.HasPrefix(text, "@") {
+		return nil, text
+	}
+
+	// Built-in commands should not be parsed as agent names
+	if isBuiltinCommand(text) {
 		return nil, text
 	}
 
@@ -214,6 +240,11 @@ func (h *Handler) parseCommand(text string) ([]string, string) {
 	for {
 		rest = strings.TrimSpace(rest)
 		if !strings.HasPrefix(rest, "/") && !strings.HasPrefix(rest, "@") {
+			break
+		}
+
+		// If this portion is a built-in command, stop parsing agent names
+		if isBuiltinCommand(rest) {
 			break
 		}
 
@@ -349,6 +380,30 @@ func (h *Handler) HandleMessage(ctx context.Context, client *ilink.Client, msg i
 			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
 		}
 		return
+	} else if strings.HasPrefix(trimmed, "/save") {
+		// Pre-parse agent prefix so "@agent /save ..." works correctly.
+		parsedAgentNames, effectiveTrimmed := h.parseCommand(text)
+		saveTrimmed := trimmed
+		if len(parsedAgentNames) > 0 && strings.HasPrefix(effectiveTrimmed, "/save") {
+			saveTrimmed = "/save @" + parsedAgentNames[0] + " " + strings.TrimPrefix(effectiveTrimmed, "/save")
+		}
+		reply := h.handleSave(ctx, client, msg, strings.TrimSpace(saveTrimmed), clientID)
+		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
+			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
+		}
+		return
+	} else if strings.HasPrefix(trimmed, "/hub") {
+		// Pre-parse agent prefix so "@agent /hub ..." works correctly.
+		parsedAgentNames, effectiveTrimmed := h.parseCommand(text)
+		hubTrimmed := trimmed
+		if len(parsedAgentNames) > 0 && strings.HasPrefix(effectiveTrimmed, "/hub") {
+			hubTrimmed = "/hub @" + parsedAgentNames[0] + " " + strings.TrimPrefix(effectiveTrimmed, "/hub")
+		}
+		reply := h.handleHub(ctx, client, msg, strings.TrimSpace(hubTrimmed), clientID)
+		if err := SendTextReply(ctx, client, msg.FromUserID, reply, msg.ContextToken, clientID); err != nil {
+			log.Printf("[handler] failed to send reply to %s: %v", msg.FromUserID, err)
+		}
+		return
 	}
 
 	// Route: "/agentname message" or "@agent1 @agent2 message" -> specific agent(s)
@@ -428,6 +483,8 @@ func (h *Handler) sendToDefaultAgent(ctx context.Context, client *ilink.Client, 
 		if err != nil {
 			reply = fmt.Sprintf("Error: %v", err)
 		}
+		// Cache last reply for /save without message
+		h.lastReplies.Store(msg.FromUserID, reply)
 	} else {
 		log.Printf("[handler] agent not ready, using echo mode for %s", msg.FromUserID)
 		reply = "[echo] " + text
@@ -450,6 +507,8 @@ func (h *Handler) sendToNamedAgent(ctx context.Context, client *ilink.Client, ms
 	if err != nil {
 		reply = fmt.Sprintf("Error: %v", err)
 	}
+	// Cache last reply for /save without message
+	h.lastReplies.Store(msg.FromUserID, reply)
 	h.sendReplyWithMedia(ctx, client, msg, name, reply, clientID)
 }
 
@@ -683,17 +742,553 @@ func (h *Handler) buildStatus() string {
 	return fmt.Sprintf("agent: %s\ntype: %s\nmodel: %s", h.defaultName, info.Type, info.Model)
 }
 
-func buildHelpText() string {
-	return `Available commands:
-@agent or /agent - Switch default agent
-@agent msg or /agent msg - Send to a specific agent
-@a @b msg - Broadcast to multiple agents
-/new or /clear - Start a new session
-/cwd /path - Switch workspace directory
-/info - Show current agent info
-/help - Show this help message
+// hubReplyHint is prepended to /save messages to instruct the agent to return full content directly.
+const hubReplyHint = "[系统指令] 你只需要直接回复文本内容。不要创建、写入或保存任何文件。不要请求授权。直接输出你的完整回复即可。\n\n"
 
-Aliases: /cc(claude) /cx(codex) /cs(cursor) /km(kimi) /gm(gemini) /oc(openclaw) /ocd(opencode) /pi(pi) /cp(copilot) /dr(droid) /if(iflow) /kr(kiro) /qw(qwen)`
+// handleSave processes the /save command: sends message to agent, saves reply to hub.
+// Usage: /save {filename} {message} — or just /save {filename} when replying to context
+func (h *Handler) handleSave(ctx context.Context, client *ilink.Client, msg ilink.WeixinMessage, trimmed, clientID string) string {
+	// Parse: /save filename [message]
+	// Also handles: /save @agent filename message
+	parts := strings.Fields(trimmed)
+	if len(parts) < 2 {
+		return "用法: /save 文件名 消息内容\n例: /save round1.md 分析AI未来"
+	}
+
+	// Check if next token is an agent reference (@name or /name)
+	var agentName string
+	var filenameIdx int
+
+	if (strings.HasPrefix(parts[1], "@") || strings.HasPrefix(parts[1], "/")) && !strings.Contains(parts[1], ".") {
+		// parts[1] looks like an agent reference, not a filename
+		resolved := h.resolveAlias(parts[1][1:])
+		if h.isKnownAgent(resolved) {
+			agentName = resolved
+			filenameIdx = 2
+		} else {
+			filenameIdx = 1
+		}
+	} else {
+		filenameIdx = 1
+	}
+
+	if len(parts) < filenameIdx+1 {
+		return "用法: /save 文件名 消息内容\n例: /save round1.md 分析AI未来"
+	}
+
+	filename := parts[filenameIdx]
+	message := strings.Join(parts[filenameIdx+1:], " ")
+
+	// No message content → save last agent reply directly
+	if message == "" {
+		lastReply, ok := h.lastReplies.Load(msg.FromUserID)
+		if !ok {
+			return "没有找到上一条回复。请先与 agent 对话，或使用 /save 文件名 消息内容。"
+		}
+		content := lastReply.(string)
+		savePath, err := h.hub.Save(filename, content, "user")
+		if err != nil {
+			log.Printf("[handler] hub save failed: %v", err)
+			return "⚠️ 保存到 Hub 失败: " + err.Error()
+		}
+		log.Printf("[handler] saved last reply to hub: %s", savePath)
+		return fmt.Sprintf("✅ 已保存上一条回复到 Hub: %s", filename)
+	}
+
+	// Has message content → send to agent, save agent's reply
+	// Determine which agent to use
+	var ag agent.Agent
+	var useName string
+	if agentName != "" {
+		var err error
+		ag, err = h.getAgent(ctx, agentName)
+		if err != nil {
+			return fmt.Sprintf("Agent %q 不可用: %v", agentName, err)
+		}
+		useName = agentName
+	} else {
+		ag = h.getDefaultAgent()
+		if ag == nil {
+			return "没有可用的 agent"
+		}
+		h.mu.RLock()
+		useName = h.defaultName
+		h.mu.RUnlock()
+	}
+
+	// Send typing
+	go func() {
+		if typingErr := SendTypingState(ctx, client, msg.FromUserID, msg.ContextToken); typingErr != nil {
+			log.Printf("[handler] failed to send typing state: %v", typingErr)
+		}
+	}()
+
+	// Use agent-specific conversationID to avoid polluting default session
+	conversationID := "hub:" + useName + ":" + msg.FromUserID
+
+	// Prepend hint to discourage agents from requesting file creation
+	promptWithHint := hubReplyHint + message
+
+	reply, err := h.chatWithAgent(ctx, ag, conversationID, promptWithHint)
+	if err != nil {
+		return fmt.Sprintf("Agent 错误: %v", err)
+	}
+
+	savePath, err := h.hub.Save(filename, reply, useName)
+	if err != nil {
+		log.Printf("[handler] hub save failed: %v", err)
+		return reply + "\n\n⚠️ 保存到 Hub 失败: " + err.Error()
+	}
+	log.Printf("[handler] saved hub reply to: %s (agent=%s)", savePath, useName)
+
+	return reply + fmt.Sprintf("\n\n✅ 已保存到 Hub: %s", filename)
+}
+
+// handleHub processes the /hub command: reads shared context and optionally sends to agent.
+// Usage:
+//
+//	/hub {message}              — read all shared files, inject context, send to default agent
+//	/hub {filename} {msg}       — read specific file, inject, send to agent
+//	/hub ls                     — list files in hub
+//	/hub clear                  — clear all hub files
+//	/hub pipe <agent> <msg>     — chain: send to default agent, pipe result to target agent
+func (h *Handler) handleHub(ctx context.Context, client *ilink.Client, msg ilink.WeixinMessage, trimmed, clientID string) string {
+	// Parse: /hub [filename] [message] | /hub ls | /hub clear
+	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, "/hub"))
+
+	// No arguments → list files
+	if rest == "" {
+		files, err := h.hub.List()
+		if err != nil {
+			return fmt.Sprintf("读取 Hub 失败: %v", err)
+		}
+		if len(files) == 0 {
+			return "Hub 是空的。使用 /save 文件名 消息 来保存内容。"
+		}
+		var sb strings.Builder
+		sb.WriteString("📁 Hub 文件列表:\n")
+		for _, f := range files {
+			sb.WriteString(fmt.Sprintf("  • %s\n", f))
+		}
+		return sb.String()
+	}
+
+	// Sub-commands
+	switch {
+	case rest == "ls" || rest == "list":
+		files, err := h.hub.ListWithInfo()
+		if err != nil {
+			return fmt.Sprintf("读取 Hub 失败: %v", err)
+		}
+		if len(files) == 0 {
+			return "Hub 是空的。"
+		}
+		var sb strings.Builder
+		sb.WriteString("📁 Hub 文件列表 (最新优先):\n")
+		for i, f := range files {
+			timeStr := f.ModTime.Format("01-02 15:04")
+			sb.WriteString(fmt.Sprintf("  [%d] %s (%s)\n", i+1, f.Name, timeStr))
+		}
+		sb.WriteString("\n💡 使用 /hub cat <编号> 读取文件")
+		return sb.String()
+
+	case strings.HasPrefix(rest, "cat "):
+		// /hub cat <number>
+		parts := strings.Fields(rest)
+		if len(parts) != 2 {
+			return "用法: /hub cat <编号>\n示例: /hub cat 1"
+		}
+		var num int
+		_, err := fmt.Sscanf(parts[1], "%d", &num)
+		if err != nil || num < 1 {
+			return fmt.Sprintf("无效的编号: %q，请使用数字", parts[1])
+		}
+		files, err := h.hub.ListWithInfo()
+		if err != nil {
+			return fmt.Sprintf("读取 Hub 失败: %v", err)
+		}
+		if num > len(files) {
+			return fmt.Sprintf("编号超出范围，Hub 只有 %d 个文件", len(files))
+		}
+		targetFile := files[num-1].Name
+		content, err := h.hub.ReadFile(targetFile)
+		if err != nil {
+			return fmt.Sprintf("读取文件失败: %v", err)
+		}
+		return fmt.Sprintf("📄 %s\n\n%s", targetFile, content)
+
+	case rest == "clear":
+		count, err := h.hub.Clear()
+		if err != nil {
+			return fmt.Sprintf("清空 Hub 失败: %v", err)
+		}
+		return fmt.Sprintf("🗑️ 已清空 Hub (%d 个文件)", count)
+
+	case strings.HasPrefix(rest, "pipe "):
+		// /hub pipe <target_agent> <message>
+		// /hub pipe <target_agent> @<编号> <message>
+		// /hub pipe <target_agent> @-1 <message>
+		// /hub pipe <target_agent> @<文件名> <消息>
+		parts := strings.Fields(rest)
+		if len(parts) < 2 {
+			return "用法: /hub pipe <目标agent> <消息>\n       /hub pipe <目标agent> @<编号> <消息>\n       /hub pipe <目标agent> @-1 <消息>\n       /hub pipe <目标agent> @<文件名> <消息>\n\n示例: /hub pipe gemini 分析量子计算\n      /hub pipe claude @1 继续分析\n      /hub pipe claude @-1 补充说明"
+		}
+		targetAgent := parts[1]
+		var message string
+		if len(parts) >= 3 && strings.HasPrefix(parts[2], "@") {
+			message = strings.Join(parts[2:], " ")
+		} else {
+			message = strings.Join(parts[2:], " ")
+			if message == "" {
+				return "用法: /hub pipe <目标agent> <消息>\n       /hub pipe <目标agent> @<编号> <消息>\n\n示例: /hub pipe gemini 分析量子计算"
+			}
+		}
+		return h.handlePipe(ctx, client, msg, targetAgent, message, clientID)
+	}
+
+	// Parse: could be "/hub filename message" or "/hub message"
+	words := strings.Fields(rest)
+	if len(words) == 0 {
+		return "用法: /hub {文件名} {消息} 或 /hub {消息}"
+	}
+
+	var hubContext string
+	var message string
+	var targetAgentName string
+	var saveFilename string
+
+	// Check if first word is an agent reference
+	wordIdx := 0
+	if (strings.HasPrefix(words[0], "@") || strings.HasPrefix(words[0], "/")) && !strings.Contains(words[0], ".") {
+		resolved := h.resolveAlias(words[0][1:])
+		if h.isKnownAgent(resolved) {
+			targetAgentName = resolved
+			wordIdx = 1
+		}
+	}
+
+	if wordIdx >= len(words) {
+		return "用法: /hub {文件名} {消息} 或 /hub {消息}"
+	}
+
+	// Check if current first word is a known hub file
+	if h.hub.Exists(words[wordIdx]) {
+		ctx2, err := h.hub.ReadSpecific([]string{words[wordIdx]})
+		if err != nil {
+			return fmt.Sprintf("读取文件失败: %v", err)
+		}
+		hubContext = ctx2
+		if len(words) > wordIdx+1 {
+			message = strings.Join(words[wordIdx+1:], " ")
+			if strings.HasSuffix(words[wordIdx], ".md") {
+				saveFilename = words[wordIdx]
+			}
+		} else {
+			message = ""
+		}
+	} else {
+		ctx2, err := h.hub.ReadAll()
+		if err != nil {
+			return fmt.Sprintf("读取 Hub 失败: %v", err)
+		}
+		hubContext = ctx2
+		message = strings.Join(words[wordIdx:], " ")
+	}
+
+	if message == "" {
+		if hubContext == "" {
+			return "Hub 是空的，没有可注入的上下文。"
+		}
+		return hubContext
+	}
+
+	// Determine target agent
+	var ag agent.Agent
+	var resolvedAgentName string
+	if targetAgentName != "" {
+		var err error
+		ag, err = h.getAgent(ctx, targetAgentName)
+		if err != nil {
+			return fmt.Sprintf("Agent %q 不可用: %v", targetAgentName, err)
+		}
+		resolvedAgentName = targetAgentName
+	} else {
+		ag = h.getDefaultAgent()
+		if ag == nil {
+			return "没有可用的 agent"
+		}
+		h.mu.RLock()
+		resolvedAgentName = h.defaultName
+		h.mu.RUnlock()
+	}
+
+	// Send typing
+	go func() {
+		if typingErr := SendTypingState(ctx, client, msg.FromUserID, msg.ContextToken); typingErr != nil {
+			log.Printf("[handler] failed to send typing state: %v", typingErr)
+		}
+	}()
+
+	// Always use agent-specific conversationID to avoid polluting default session
+	conversationID := "hub:" + resolvedAgentName + ":" + msg.FromUserID
+
+	wrappedMessage := fmt.Sprintf(
+		"【重要】请直接基于下方提供的材料回答问题。禁止使用任何工具（搜索、读文件、写文件等），不要访问文件系统，不要搜索网络。材料已完整提供给你，直接分析即可。\n\n---\n共享材料：\n%s\n---\n\n问题：%s",
+		hubContext, message,
+	)
+
+	reply, err := h.chatWithAgent(ctx, ag, conversationID, wrappedMessage)
+	if err != nil {
+		return fmt.Sprintf("Agent 错误: %v", err)
+	}
+
+	// Auto-save reply if a specific .md file was referenced
+	if saveFilename != "" {
+		savePath, err := h.hub.Save(saveFilename, reply, resolvedAgentName)
+		if err != nil {
+			log.Printf("[handler] hub auto-save failed: %v", err)
+		} else {
+			log.Printf("[handler] auto-saved hub reply to: %s (agent=%s)", savePath, resolvedAgentName)
+			return reply + fmt.Sprintf("\n\n✅ 已保存到 Hub: %s", saveFilename)
+		}
+	}
+
+	return reply
+}
+
+// handlePipe implements agent chaining: send message to default agent, save reply, send to target agent.
+// Supports @ reference syntax:
+//
+//	/hub pipe <agent> @<number> <msg> — use hub file by number
+//	/hub pipe <agent> @-1 <msg>       — use latest file
+//	/hub pipe <agent> @<filename> <msg> — use file by name (partial match supported)
+func (h *Handler) handlePipe(ctx context.Context, client *ilink.Client, msg ilink.WeixinMessage, targetAgent, message, clientID string) string {
+	log.Printf("[hub/pipe] starting pipe: target=%s, message=%q", targetAgent, truncate(message, 50))
+
+	timestamp := time.Now().Format("20060102-150405")
+
+	var reply1 string
+	var filename string
+	var sourceAgentName string
+
+	// Check for @ reference syntax
+	trimmedMsg := strings.TrimSpace(message)
+	if strings.HasPrefix(trimmedMsg, "@") {
+		refStr := trimmedMsg[1:] // strip @
+
+		// Try numeric reference (@1, @-1, @2)
+		var refNum int
+		n, err := fmt.Sscanf(refStr, "%d", &refNum)
+
+		if n == 1 && err == nil {
+			files, ferr := h.hub.ListWithInfo()
+			if ferr != nil {
+				return fmt.Sprintf("❌ 读取 Hub 失败: %v", ferr)
+			}
+			if len(files) == 0 {
+				return "❌ Hub 是空的，没有可引用的文件"
+			}
+
+			var targetFile string
+			if refNum < 0 {
+				// Relative: @-1=latest, @-2=second latest
+				idx := -refNum - 1
+				if idx >= len(files) {
+					return fmt.Sprintf("❌ 相对编号超出范围，Hub 只有 %d 个文件", len(files))
+				}
+				targetFile = files[idx].Name
+				sourceAgentName = fmt.Sprintf("Hub[@%d=最新]", refNum)
+			} else {
+				// Absolute: @1=latest, @2=second
+				if refNum > len(files) {
+					return fmt.Sprintf("❌ 编号超出范围，Hub 只有 %d 个文件", len(files))
+				}
+				targetFile = files[refNum-1].Name
+				sourceAgentName = fmt.Sprintf("Hub[@%d]", refNum)
+			}
+
+			content, cerr := h.hub.ReadFile(targetFile)
+			if cerr != nil {
+				return fmt.Sprintf("❌ 读取文件 %s 失败: %v", targetFile, cerr)
+			}
+			reply1 = content
+			filename = targetFile
+			log.Printf("[hub/pipe] using hub reference @%s -> file %s", refStr, targetFile)
+		} else {
+			// Try filename reference @filename.md or partial match
+			refFilename := refStr
+			if spaceIdx := strings.Index(refStr, " "); spaceIdx > 0 {
+				refFilename = refStr[:spaceIdx]
+				// Remaining text after @filename becomes part of message context
+				message = strings.TrimSpace(refStr[spaceIdx:])
+			} else {
+				refFilename = refStr
+				message = ""
+			}
+
+			// Try exact match first
+			if h.hub.Exists(refFilename) {
+				content, cerr := h.hub.ReadFile(refFilename)
+				if cerr != nil {
+					return fmt.Sprintf("❌ 读取文件 %s 失败: %v", refFilename, cerr)
+				}
+				reply1 = content
+				filename = refFilename
+				sourceAgentName = fmt.Sprintf("Hub[%s]", refFilename)
+				log.Printf("[hub/pipe] using hub file reference @%s", refFilename)
+			} else {
+				// Try partial match
+				matchedFile, err := h.hub.FindByPartialName(refFilename)
+				if err == nil {
+					content, cerr := h.hub.ReadFile(matchedFile)
+					if cerr != nil {
+						return fmt.Sprintf("❌ 读取文件 %s 失败: %v", matchedFile, cerr)
+					}
+					reply1 = content
+					filename = matchedFile
+					sourceAgentName = fmt.Sprintf("Hub[%s]", refFilename)
+					log.Printf("[hub/pipe] using hub partial match @%s -> file %s", refFilename, matchedFile)
+				} else {
+					return fmt.Sprintf("❌ 找不到匹配 %q 的文件\n\n💡 提示:\n- 使用 @<编号>: @1、@-1\n- 使用 @<部分文件名>: @gemini\n- 查看文件: /hub list", refFilename)
+				}
+			}
+		}
+	}
+
+	// No @ reference → normal pipe: send to default agent first
+	if reply1 == "" {
+		sourceAgent := h.getDefaultAgent()
+		if sourceAgent == nil {
+			return "❌ 没有可用的默认 agent，请先设置默认 agent（如 /claude）"
+		}
+
+		h.mu.RLock()
+		sourceAgentName = h.defaultName
+		h.mu.RUnlock()
+
+		log.Printf("[hub/pipe] step1: sending to default agent (%s)", sourceAgentName)
+		var err error
+		reply1, err = h.chatWithAgent(ctx, sourceAgent, msg.FromUserID, message)
+		if err != nil {
+			return fmt.Sprintf("❌ 第一步（默认 agent %s）失败: %v", sourceAgentName, err)
+		}
+
+		shortAgentName := sourceAgentName
+		if idx := strings.LastIndex(sourceAgentName, "/"); idx >= 0 {
+			shortAgentName = sourceAgentName[idx+1:]
+		}
+		filename = fmt.Sprintf("pipe_%s_%s.md", timestamp, shortAgentName)
+		savePath, err := h.hub.Save(filename, reply1, sourceAgentName)
+		if err != nil {
+			log.Printf("[hub/pipe] save failed: %v", err)
+			filename = ""
+		} else {
+			log.Printf("[hub/pipe] saved step1 reply to %s", savePath)
+		}
+	}
+
+	// Get target agent
+	targetAg, err := h.getAgent(ctx, targetAgent)
+	if err != nil {
+		return fmt.Sprintf("❌ 目标 agent %q 不可用: %v", targetAgent, err)
+	}
+
+	// Build prompt for target agent based on saved hub file
+	var hubContext string
+	if filename != "" {
+		hubContext, err = h.hub.ReadSpecific([]string{filename})
+		if err != nil {
+			log.Printf("[hub/pipe] read saved file failed: %v", err)
+			hubContext = ""
+		}
+	}
+
+	if hubContext == "" {
+		hubContext = fmt.Sprintf("上一步的回复：\n%s", reply1)
+	}
+
+	secondPrompt := fmt.Sprintf(
+		"请基于以下内容，继续进行分析或给出你的观点：\n\n---\n%s\n---\n\n要求：直接输出分析结果，不要重复原文。",
+		hubContext,
+	)
+
+	convID := "hub:" + targetAgent + ":" + msg.FromUserID
+	log.Printf("[hub/pipe] step2: sending to target agent (%s)", targetAgent)
+	reply2, err := h.chatWithAgent(ctx, targetAg, convID, secondPrompt)
+	if err != nil {
+		return fmt.Sprintf("❌ 第二步（目标 agent %s）失败: %v", targetAgent, err)
+	}
+
+	// Auto-save final result
+	finalFilename := fmt.Sprintf("pipe_%s_%s_final.md", timestamp, targetAgent)
+	finalSaved := false
+	if _, err := h.hub.Save(finalFilename, reply2, targetAgent); err != nil {
+		log.Printf("[hub/pipe] failed to save final reply: %v", err)
+	} else {
+		finalSaved = true
+	}
+
+	// Return result with file info
+	result := reply2
+	if filename != "" || finalSaved {
+		files, _ := h.hub.ListWithInfo()
+
+		var sourceNum, finalNum int
+		for i, f := range files {
+			if f.Name == filename {
+				sourceNum = i + 1
+			}
+			if f.Name == finalFilename {
+				finalNum = i + 1
+			}
+		}
+
+		var fileInfo strings.Builder
+		fileInfo.WriteString(fmt.Sprintf("\n\n📁 Pipe 流程: %s → %s", sourceAgentName, targetAgent))
+
+		if filename != "" && sourceNum > 0 {
+			fileInfo.WriteString(fmt.Sprintf("\n💾 源文件: [@%d] %s", sourceNum, filename))
+		}
+		if finalSaved && finalNum > 0 {
+			fileInfo.WriteString(fmt.Sprintf("\n💾 结果: [@%d] %s", finalNum, finalFilename))
+		}
+
+		if finalNum > 0 {
+			fileInfo.WriteString(fmt.Sprintf("\n\n💡 继续分析: /hub pipe <agent> @%d <消息>", finalNum))
+		}
+
+		result += fileInfo.String()
+	}
+	return result
+}
+
+func buildHelpText() string {
+	return `🤖 WeClaw Agent Hub
+
+📌 基本指令
+  @agent msg       发给指定 agent
+  @a @b msg        广播给多个 agent
+  /new /clear      开始新会话
+  /cwd /path       切换工作目录
+  /info            显示当前 agent 信息
+  /help            显示此帮助信息
+
+🗂️ Hub 共享上下文
+  /save <文件名> <消息>   让 agent 回答并保存到 Hub
+  /save <文件名>          保存上一条回复到 Hub
+  /hub                   列出 Hub 文件
+  /hub ls                查看文件列表（带编号）
+  /hub cat <编号>         查看文件内容
+  /hub <消息>             注入所有 Hub 上下文，发给 agent
+  /hub <文件名> <消息>    注入指定文件，发给 agent
+  /hub clear             清空 Hub
+
+🔗 Pipe 链式协作
+  /hub pipe <agent> <消息>         默认agent→保存→目标agent
+  /hub pipe <agent> @<编号> <消息>  直接用 Hub 文件作为输入
+  /hub pipe <agent> @-1 <消息>     用最新 Hub 文件作为输入
+
+Aliases: /cc(claude) /cx(codex) /cs(cursor) /km(kimi) /gm(gemini) /oc(openclaw) /qw(qwen)`
 }
 
 func extractText(msg ilink.WeixinMessage) string {


### PR DESCRIPTION
…b, /hub pipe

Implements the Agent Hub system: a filesystem-based shared blackboard that lets multiple AI agents collaborate by exchanging intermediate results through a common context store.

## New Commands

### /save — save agent replies to Hub
  /save <filename> <message>   Send to agent, save reply to Hub
  /save <filename>             Save last agent reply directly to Hub
  /save @claude filename msg   Target a specific agent

### /hub — inject shared context into agent
  /hub                         List hub files
  /hub ls                      Detailed listing with numbered index
  /hub cat <n>                 Read file by number
  /hub <message>               Inject all hub context, send to agent
  /hub <filename> <message>    Inject specific file, send to agent
  /hub clear                   Delete all hub files

### /hub pipe — chain agents automatically
  /hub pipe <agent> <message>       Default agent → save → target agent
  /hub pipe <agent> @<n> <message>  Use hub file #n as input
  /hub pipe <agent> @-1 <message>   Use latest hub file as input
  /hub pipe <agent> @<name> <msg>   Partial filename match

## Design

- Pure Go, zero new dependencies
- Storage: ~/.weclaw/hub/shared/ (Markdown + YAML frontmatter)
- Thread-safe: sync.RWMutex on Hub struct
- Session isolation: hub:<agent>:<userID> conversationID prevents cross-contamination of default chat sessions
- Agents are instructed to return raw content, not create files

## Files

- hub/hub.go:          Hub core — Save, ReadAll, ReadSpecific, List,
                       ListWithInfo, FindByPartialName, Clear, Exists
- hub/hub_test.go:     11 unit tests (all passing)
- docs/agent-hub-design.md: Architecture design document
- messaging/handler.go: /save, /hub, /hub pipe command integration

## Example Workflow

  /save round1.md  Analyze AI agents from a philosophical angle /hub pipe gemini @1  Continue with a technical feasibility critique /hub pipe claude @-1  Synthesize both perspectives