### PR TITLE
Fix process management commands on Windows (stop/status/restart)

### DIFF
--- a/cmd/proc_unix.go
+++ b/cmd/proc_unix.go
@@ -3,10 +3,37 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func processExists(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+func stopAllWeclaw() {
+	if pid, err := readPid(); err == nil && processExists(pid) {
+		if p, err := os.FindProcess(pid); err == nil {
+			_ = p.Signal(syscall.SIGTERM)
+		}
+	}
+	os.Remove(pidFile())
+
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	_ = exec.Command("pkill", "-f", exe+" start").Run()
+	time.Sleep(500 * time.Millisecond)
 }

--- a/cmd/proc_windows.go
+++ b/cmd/proc_windows.go
@@ -2,8 +2,30 @@
 
 package cmd
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
 
 func setSysProcAttr(_ *exec.Cmd) {
-	// No Setsid on Windows — process is already detached via Start()
+}
+
+func processExists(pid int) bool {
+	out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid)).Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), fmt.Sprintf(" %d ", pid))
+}
+
+func stopAllWeclaw() {
+	if pid, err := readPid(); err == nil && processExists(pid) {
+		_ = exec.Command("taskkill", "/F", "/PID", fmt.Sprintf("%d", pid)).Run()
+	}
+	os.Remove(pidFile())
+	_ = exec.Command("taskkill", "/F", "/IM", "weclaw.exe").Run()
+	time.Sleep(500 * time.Millisecond)
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -17,23 +14,7 @@ var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restart the background weclaw process",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Stop if running
-		pid, err := readPid()
-		if err == nil && processExists(pid) {
-			fmt.Printf("Stopping weclaw (pid=%d)...\n", pid)
-			if p, err := os.FindProcess(pid); err == nil {
-				p.Signal(syscall.SIGTERM)
-			}
-			for i := 0; i < 20; i++ {
-				if !processExists(pid) {
-					break
-				}
-				time.Sleep(500 * time.Millisecond)
-			}
-			os.Remove(pidFile())
-		}
-
-		// Start
+		stopAllWeclaw()
 		fmt.Println("Starting weclaw...")
 		return runDaemon()
 	},

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,31 +405,4 @@ func readPid() (int, error) {
 	return pid, nil
 }
 
-func processExists(pid int) bool {
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// Signal 0 checks if process exists without killing it
-	return p.Signal(syscall.Signal(0)) == nil
-}
 
-// stopAllWeclaw kills all running weclaw processes (by PID file and by process scan).
-func stopAllWeclaw() {
-	// 1. Kill by PID file
-	if pid, err := readPid(); err == nil && processExists(pid) {
-		if p, err := os.FindProcess(pid); err == nil {
-			_ = p.Signal(syscall.SIGTERM)
-		}
-	}
-	os.Remove(pidFile())
-
-	// 2. Kill any remaining weclaw processes by scanning
-	exe, err := os.Executable()
-	if err != nil {
-		return
-	}
-	// Use pkill to kill all processes matching the executable path
-	_ = exec.Command("pkill", "-f", exe+" start").Run()
-	time.Sleep(500 * time.Millisecond)
-}


### PR DESCRIPTION
## Problem

`weclaw stop`, `weclaw status`, and `weclaw restart` are broken on Windows. The functions `processExists()` and `stopAllWeclaw()` in `cmd/start.go` use Unix-only APIs (`syscall.Signal(0)`, `syscall.SIGTERM`, `pkill`) with no platform-specific handling.

- `processExists()` uses `p.Signal(syscall.Signal(0))` — on Windows, `os.FindProcess` always succeeds and signal 0 is not supported, so this always returns wrong results
- `stopAllWeclaw()` uses `SIGTERM` and `pkill` — neither works on Windows
- `restart` duplicates the same broken logic inline

## Changes

1. Move `processExists()` and `stopAllWeclaw()` out of `cmd/start.go` into platform-specific files with build tags
2. `cmd/proc_unix.go` (`//go:build !windows`) — unchanged Unix implementation
3. `cmd/proc_windows.go` (`//go:build windows`) — Windows implementation using `tasklist`/`taskkill`
4. `cmd/restart.go` — delegate to `stopAllWeclaw()` instead of duplicating logic

## Testing

Verified on Windows 11: `weclaw status` now correctly reports the running PID, `weclaw stop` actually terminates the process, and `weclaw restart` works end-to-end.

Closes #74
